### PR TITLE
Remove nonTransitiveRClass flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true


### PR DESCRIPTION
It's the default from AGP 8.0, see https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes