### PR TITLE
Remove scaffold contentPadding consumption

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
@@ -101,7 +101,7 @@ class CommonUiActivity : ComponentActivity() {
                         }
                     }
                 }
-            ) { contentPadding ->
+            ) { _ ->
                 NavDisplay(
                     backStack = topLevelBackStack.backStack,
                     onBack = { topLevelBackStack.removeLast() },
@@ -123,9 +123,6 @@ class CommonUiActivity : ComponentActivity() {
                             ContentPurple("Camera screen")
                         }
                     },
-                    modifier = Modifier
-                        .padding(contentPadding)
-                        .consumeWindowInsets(contentPadding)
                 )
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.Home
@@ -122,7 +123,9 @@ class CommonUiActivity : ComponentActivity() {
                             ContentPurple("Camera screen")
                         }
                     },
-                    modifier = Modifier.consumeWindowInsets(contentPadding)
+                    modifier = Modifier
+                        .padding(contentPadding)
+                        .consumeWindowInsets(contentPadding)
                 )
             }
         }


### PR DESCRIPTION
| Before    | After |
| -------- | ------- |
| <img src="https://github.com/user-attachments/assets/011f5098-7e8a-45f6-8df7-6e5e0ab244fd" alt="Sample Image" height="480">  | <img src="https://github.com/user-attachments/assets/d1fddca7-0ca1-4f0c-881a-748c6473b65e" alt="Sample Image" height="480">    |


#### The problem:
system bar padding are not being applied

#### Why:
NavHost is consuming scaffold `paddingValues` without applying them. 


ContentRed, ContentGreeen etc… have `safeDrawingPadding()` modifier so they would add system bar paddings but, their parent composable (NavHost) already used/consumed them
