### PR TITLE
Enhance README with NavigationBar and back stack explanation for bottom navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are the recipes and what they demonstrate.
 - **[Animations](app/src/main/java/com/example/nav3recipes/animations)**: Override the default animations for all destinations and a single destination.
 
 **Common use cases**
-- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: A common navigation toolbar where each item in the toolbar navigates to a top level destination.
+- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: Common navigation UI: A common bottom navigation where each item navigates to a top-level destination. This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.
 - **[Conditional navigation](app/src/main/java/com/example/nav3recipes/conditional)**: Switch to a different navigation flow when a condition is met. For example, for authentication or first-time user onboarding.
 
 **Planned**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are the recipes and what they demonstrate.
 - **[Animations](app/src/main/java/com/example/nav3recipes/animations)**: Override the default animations for all destinations and a single destination.
 
 **Common use cases**
-- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: A common bottom navigation where each item navigates to a top-level destination. This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.
+- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: A common bottom navigation where each item navigates to a top-level destination.This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.
 - **[Conditional navigation](app/src/main/java/com/example/nav3recipes/conditional)**: Switch to a different navigation flow when a condition is met. For example, for authentication or first-time user onboarding.
 
 **Planned**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These are the recipes and what they demonstrate.
 - **[Animations](app/src/main/java/com/example/nav3recipes/animations)**: Override the default animations for all destinations and a single destination.
 
 **Common use cases**
-- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: Common navigation UI: A common bottom navigation where each item navigates to a top-level destination. This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.
+- **[Common navigation UI](app/src/main/java/com/example/nav3recipes/commonui)**: A common bottom navigation where each item navigates to a top-level destination. This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.
 - **[Conditional navigation](app/src/main/java/com/example/nav3recipes/conditional)**: Switch to a different navigation flow when a condition is met. For example, for authentication or first-time user onboarding.
 
 **Planned**


### PR DESCRIPTION
This pull request updates the description under the "Common navigation UI" section in the **README.md** file.

**Changes made:**

Replaced the word "toolbar" with a more accurate term: NavigationBar.
Added a clarification about how each item represents a top-level destination.
Mentioned the usage of TopLevelBackStack for managing independent back stacks.
This change aims to improve clarity for developers exploring Navigation3 usage with bottom navigation patterns.

**Related Discussion:**

N/A – Minor improvement, but can be linked to ongoing clarity improvements for new adopters.

**Preview of the New Text:**

> Common navigation UI: A common bottom navigation where each item navigates to a top-level destination. This example uses Material3's NavigationBar, with each destination preserving its own back stack using a TopLevelBackStack manager.

