### PR TITLE
Revert "Update libs.versions.toml"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,53 +13,53 @@
 # limitations under the License.
 
 [versions]
-agp                                    = "8.10.0"
-kotlin                                 = "2.1.20"
-kotlinSerialization                    = "2.1.21"
-coreKtx                                = "1.16.0"
-junit                                  = "4.13.2"
-junitVersion                           = "1.2.1"
-espressoCore                           = "3.6.1"
-kotlinxSerializationCore               = "1.8.1"
-kotlinxSerializationJson               = "1.6.3"
-lifecycleRuntimeKtx                    = "2.8.7"
-lifecycleViewmodel                     = "1.0.0-SNAPSHOT"
-activityCompose                        = "1.12.0-alpha01"
-composeBom                             = "2025.04.01"
-navigation3                            = "1.0.0-alpha01"
-material3                              = "1.4.0-alpha13"
-nav3Material                           = "1.0.0-SNAPSHOT"
-ksp                                    = "2.1.20-2.0.0"
-hilt                                   = "2.56.2"
+agp = "8.10.0"
+kotlin = "2.1.20"
+kotlinSerialization = "2.1.21"
+coreKtx = "1.16.0"
+junit = "4.13.2"
+junitVersion = "1.2.1"
+espressoCore = "3.6.1"
+kotlinxSerializationCore = "1.8.1"
+kotlinxSerializationJson = "1.6.3"
+lifecycleRuntimeKtx = "2.8.7"
+lifecycleViewmodel = "1.0.0-SNAPSHOT"
+activityCompose = "1.10.1"
+composeBom = "2025.04.01"
+navigation3 = "1.0.0-alpha01"
+material3 = "1.4.0-alpha13"
+nav3Material = "1.0.0-SNAPSHOT"
+ksp = "2.1.20-2.0.0"
+hilt = "2.56.2"
 
 [libraries]
-androidx-core-ktx                = { group = "androidx.core",           name = "core-ktx", version.ref = "coreKtx" }
-junit                            = { group = "junit",                   name = "junit", version.ref = "junit" }
-androidx-junit                   = { group = "androidx.test.ext",       name = "junit", version.ref = "junitVersion" }
-androidx-espresso-core           = { group = "androidx.test.espresso",  name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx   = { group = "androidx.lifecycle",      name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
-androidx-activity-compose        = { group = "androidx.activity",       name = "activity-compose", version.ref = "activityCompose" }
-androidx-compose-bom             = { group = "androidx.compose",        name = "compose-bom-alpha", version.ref = "composeBom" }
-androidx-ui                      = { group = "androidx.compose.ui",     name = "ui" }
-androidx-ui-graphics             = { group = "androidx.compose.ui",     name = "ui-graphics" }
-androidx-ui-tooling              = { group = "androidx.compose.ui",     name = "ui-tooling" }
-androidx-ui-tooling-preview      = { group = "androidx.compose.ui",     name = "ui-tooling-preview" }
-androidx-ui-test-manifest        = { group = "androidx.compose.ui",     name = "ui-test-manifest" }
-androidx-ui-test-junit4          = { group = "androidx.compose.ui",     name = "ui-test-junit4" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom-alpha", version.ref = "composeBom" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 
-androidx-material3                       = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
-androidx-material3-windowsizeclass       = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3" }
-androidx-material3-adaptive-layout       = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout", version.ref = "material3" }
-androidx-adaptive-layout                 = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-material3-windowsizeclass = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3" }
+androidx-material3-adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout", version.ref = "material3" }
+androidx-adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout" }
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodel" }
-androidx-navigation3-runtime             = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
-androidx-navigation3-ui                  = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
-hilt-android                             = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-compiler                            = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
-kotlinx-serialization-core               = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
-kotlinx-serialization-json               = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
-androidx-material-icons-extended         = { group = "androidx.compose.material", name = "material-icons-extended" }
-androidx-material3-navigation3           = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+androidx-material3-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
 
 
 [plugins]


### PR DESCRIPTION
Reverts android/nav3-recipes#15. 

I'm reverting this because while it is definitely more readable, it has an unwanted side effect: If you add a new dependency that has a longer name than the longest current name you have to reformat everything. 

Additionally, the current format is inconsistent: why is there a line break halfway through the libraries section where the format changes? why don't the `name` and `version.ref` fields have consistent spacing. 

All in all, I think it was better the way it was. 