### PR TITLE
Add koin injected ViewModel recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ These are the recipes and what they demonstrate.
 ### Passing navigation arguments to ViewModels
 - **[Basic ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/basicviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `viewModel()`
 - **[Hilt injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/injectedviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `hiltViewModel()`
+- **[Koin injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/injectedviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `koinViewModel()`
 
 ### Planned
 - **Deeplinks**: Create and handle deeplinks to specific destinations

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ These are the recipes and what they demonstrate.
 - **[Modularized navigation code](app/src/main/java/com/example/nav3recipes/modular/hilt)**: Demonstrates how to decouple navigation code into separate modules (uses Dagger/Hilt for DI). 
 
 ### Passing navigation arguments to ViewModels
-- **[Basic ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/basicviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `viewModel()`
-- **[Hilt injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/injectedviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `hiltViewModel()`
-- **[Koin injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/injectedviewmodels)**: Navigation arguments are passed to a ViewModel constructed using `koinViewModel()`
+- **[Basic ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic)**: Navigation arguments are passed to a ViewModel constructed using `viewModel()`
+- **[Hilt injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt)**: Navigation arguments are passed to a ViewModel constructed using `hiltViewModel()`
+- **[Koin injected ViewModel](app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin)**: Navigation arguments are passed to a ViewModel constructed using `koinViewModel()`
 
 ### Planned
 - **Deeplinks**: Create and handle deeplinks to specific destinations

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
+
+    implementation(libs.koin.compose.viewmodel)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,9 +83,8 @@ dependencies {
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
-
-
     implementation(libs.koin.compose.viewmodel)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,15 +86,20 @@
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
-            android:name=".passingarguments.basicviewmodels.BasicViewModelsActivity"
+            android:name=".passingarguments.viewmodels.basic.BasicViewModelsActivity"
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
-            android:name=".passingarguments.injectedviewmodels.InjectedViewModelsActivity"
+            android:name=".passingarguments.viewmodels.hilt.HiltViewModelsActivity"
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
             android:name=".modular.hilt.ModularActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.Nav3Recipes"/>
+        <activity
+            android:name=".passingarguments.viewmodels.koin.KoinViewModelsActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Nav3Recipes"/>

--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -33,8 +33,9 @@ import com.example.nav3recipes.commonui.CommonUiActivity
 import com.example.nav3recipes.conditional.ConditionalActivity
 import com.example.nav3recipes.dialog.DialogActivity
 import com.example.nav3recipes.modular.hilt.ModularActivity
-import com.example.nav3recipes.passingarguments.basicviewmodels.BasicViewModelsActivity
-import com.example.nav3recipes.passingarguments.injectedviewmodels.InjectedViewModelsActivity
+import com.example.nav3recipes.passingarguments.viewmodels.basic.BasicViewModelsActivity
+import com.example.nav3recipes.passingarguments.viewmodels.hilt.HiltViewModelsActivity
+import com.example.nav3recipes.passingarguments.viewmodels.koin.KoinViewModelsActivity
 import com.example.nav3recipes.scenes.materiallistdetail.MaterialListDetailActivity
 import com.example.nav3recipes.scenes.materialsupportingpane.MaterialSupportingPaneActivity
 import com.example.nav3recipes.scenes.twopane.TwoPaneActivity
@@ -70,9 +71,10 @@ private val recipes = listOf(
     Heading("Architecture"),
     Recipe("Modular Navigation", ModularActivity::class.java),
 
-    Heading("Passing navigation arguments"),
-    Recipe("Argument passing to basic ViewModel", BasicViewModelsActivity::class.java),
-    Recipe("Argument passing to injected ViewModel", InjectedViewModelsActivity::class.java),
+    Heading("Passing navigation arguments using ViewModels"),
+    Recipe("Basic", BasicViewModelsActivity::class.java),
+    Recipe("Using Hilt", HiltViewModelsActivity::class.java),
+    Recipe("Using Koin", KoinViewModelsActivity::class.java),
 )
 
 class RecipePickerActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic/BasicViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic/BasicViewModelsActivity.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.nav3recipes.passingarguments.basicviewmodels
+package com.example.nav3recipes.passingarguments.viewmodels.basic
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt/HiltViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt/HiltViewModelsActivity.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.passingarguments.viewmodels.hilt
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entry
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
+import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
+import com.example.nav3recipes.content.ContentBlue
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.passingarguments.viewmodels.basic.RouteB
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.HiltViewModel
+
+/**
+ * Passing navigation arguments to a Hilt injected ViewModel
+ *
+ * - ViewModelStoreNavEntryDecorator ensures that ViewModels are scoped to the NavEntry
+ * - Assisted injection is used to construct ViewModels with the navigation key
+ */
+
+data object RouteA
+data class RouteB(val id: String)
+
+@AndroidEntryPoint
+class HiltViewModelsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = remember { mutableStateListOf<Any>(RouteA) }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+
+                // In order to add the `ViewModelStoreNavEntryDecorator` (see comment below for why)
+                // we also need to add the default `NavEntryDecorator`s as well. These provide
+                // extra information to the entry's content to enable it to display correctly
+                // and save its state.
+                entryDecorators = listOf(
+                    rememberSceneSetupNavEntryDecorator(),
+                    rememberSavedStateNavEntryDecorator(),
+                    rememberViewModelStoreNavEntryDecorator()
+                ),
+                entryProvider = entryProvider {
+                    entry<RouteA> {
+                        ContentGreen("Welcome to Nav3") {
+                            LazyColumn {
+                                items(10) { i ->
+                                    Button(onClick = {
+                                        backStack.add(RouteB("$i"))
+                                    }) {
+                                        Text("$i")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    entry<RouteB> { key ->
+                        val viewModel = hiltViewModel<RouteBViewModel, RouteBViewModel.Factory>(
+                            // Note: We need a new ViewModel for every new RouteB instance. Usually
+                            // we would need to supply a `key` String that is unique to the
+                            // instance, however, the ViewModelStoreNavEntryDecorator (supplied
+                            // above) does this for us, using `NavEntry.contentKey` to uniquely
+                            // identify the viewModel.
+                            //
+                            // tl;dr: Make sure you use rememberViewModelStoreNavEntryDecorator()
+                            // if you want a new ViewModel for each new navigation key instance.
+                            creationCallback = { factory ->
+                                factory.create(key)
+                            }
+                        )
+                        ScreenB(viewModel = viewModel)
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun ScreenB(viewModel: RouteBViewModel) {
+    ContentBlue("Route id: ${viewModel.navKey.id} ")
+}
+
+@HiltViewModel(assistedFactory = RouteBViewModel.Factory::class)
+class RouteBViewModel @AssistedInject constructor(
+    @Assisted val navKey: RouteB
+) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(navKey: RouteB): RouteBViewModel
+    }
+}

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
@@ -1,20 +1,4 @@
-/*
- * Copyright 2025 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package com.example.nav3recipes.passingarguments.injectedviewmodels
+package com.example.nav3recipes.passingarguments.viewmodels.koin
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -25,7 +9,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entry
@@ -35,28 +18,38 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.example.nav3recipes.content.ContentBlue
 import com.example.nav3recipes.content.ContentGreen
-import com.example.nav3recipes.passingarguments.basicviewmodels.RouteB
+import com.example.nav3recipes.passingarguments.viewmodels.basic.RouteB
 import com.example.nav3recipes.ui.setEdgeToEdgeConfig
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
-import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.lifecycle.HiltViewModel
+import org.koin.android.ext.koin.androidContext
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.context.GlobalContext
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.module
 
 /**
- * Passing navigation arguments to a Hilt injected ViewModel
+ * Passing navigation arguments to a Koin injected ViewModel
  *
  * - ViewModelStoreNavEntryDecorator ensures that ViewModels are scoped to the NavEntry
- * - Assisted injection is used to construct ViewModels with the navigation key
  */
 
 data object RouteA
 data class RouteB(val id: String)
 
-@AndroidEntryPoint
-class InjectedViewModelsActivity : ComponentActivity() {
+class KoinViewModelsActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+
+        // The startKoin block should be placed in Application.onCreate.
+        GlobalContext.startKoin {
+            androidContext(this@KoinViewModelsActivity)
+            modules(
+                module {
+                    viewModelOf(::RouteBViewModel)
+                }
+            )
+        }
+
         setEdgeToEdgeConfig()
         super.onCreate(savedInstanceState)
         setContent {
@@ -90,19 +83,9 @@ class InjectedViewModelsActivity : ComponentActivity() {
                         }
                     }
                     entry<RouteB> { key ->
-                        val viewModel = hiltViewModel<RouteBViewModel, RouteBViewModel.Factory>(
-                            // Note: We need a new ViewModel for every new RouteB instance. Usually
-                            // we would need to supply a `key` String that is unique to the
-                            // instance, however, the ViewModelStoreNavEntryDecorator (supplied
-                            // above) does this for us, using `NavEntry.contentKey` to uniquely
-                            // identify the viewModel.
-                            //
-                            // tl;dr: Make sure you use rememberViewModelStoreNavEntryDecorator()
-                            // if you want a new ViewModel for each new navigation key instance.
-                            creationCallback = { factory ->
-                                factory.create(key)
-                            }
-                        )
+                        val viewModel = koinViewModel<RouteBViewModel> {
+                            parametersOf(key)
+                        }
                         ScreenB(viewModel = viewModel)
                     }
                 }
@@ -116,13 +99,4 @@ fun ScreenB(viewModel: RouteBViewModel) {
     ContentBlue("Route id: ${viewModel.navKey.id} ")
 }
 
-@HiltViewModel(assistedFactory = RouteBViewModel.Factory::class)
-class RouteBViewModel @AssistedInject constructor(
-    @Assisted val navKey: RouteB
-) : ViewModel() {
-
-    @AssistedFactory
-    interface Factory {
-        fun create(navKey: RouteB): RouteBViewModel
-    }
-}
+class RouteBViewModel(val navKey: RouteB) : ViewModel()

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
@@ -18,7 +18,6 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import com.example.nav3recipes.content.ContentBlue
 import com.example.nav3recipes.content.ContentGreen
-import com.example.nav3recipes.passingarguments.viewmodels.basic.RouteB
 import com.example.nav3recipes.ui.setEdgeToEdgeConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.compose.viewmodel.koinViewModel
@@ -41,13 +40,15 @@ class KoinViewModelsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
 
         // The startKoin block should be placed in Application.onCreate.
-        GlobalContext.startKoin {
-            androidContext(this@KoinViewModelsActivity)
-            modules(
-                module {
-                    viewModelOf(::RouteBViewModel)
-                }
-            )
+        if (GlobalContext.getOrNull() == null) {
+            GlobalContext.startKoin {
+                androidContext(this@KoinViewModelsActivity)
+                modules(
+                    module {
+                        viewModelOf(::RouteBViewModel)
+                    }
+                )
+            }
         }
 
         setEdgeToEdgeConfig()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ nav3Material = "1.0.0-alpha02"
 ksp = "2.2.0-2.0.2"
 hilt = "2.57.1"
 hiltNavigationCompose = "1.3.0"
+koin = "4.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -59,6 +60,7 @@ kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationCore" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-material3-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "nav3Material" }
+koin-compose-viewmodel = {group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koin"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR adds a recipe that demonstrates how to use Koin to create a ViewModel. The route is passed to the ViewModel during construction. Example: 

```
entry<RouteB> { key ->
    val viewModel = koinViewModel<RouteBViewModel> {
        parametersOf(key)
    }
    ScreenB(viewModel = viewModel)
}
```