### PR TITLE
Fix error message in ResultEventBus current

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/results/event/ResultEventBus.kt
+++ b/app/src/main/java/com/example/nav3recipes/results/event/ResultEventBus.kt
@@ -37,7 +37,7 @@ object LocalResultEventBus {
      */
     val current: ResultEventBus
         @Composable
-        get() = LocalResultEventBus.current ?: error("No ResultStore has been provided")
+        get() = LocalResultEventBus.current ?: error("No ResultEventBus has been provided")
 
     /**
      * Provides a [ResultEventBus] to the composition


### PR DESCRIPTION
I fixed the error message for the `ResultStore` that was appearing in the `ResultEventBus`.