### PR TITLE
Rename deeplink.basic.deeplinkutil package

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/MainActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/MainActivity.kt
@@ -10,11 +10,11 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
-import com.example.nav3recipes.deeplink.basic.deeplinkutil.DeepLinkMatcher
-import com.example.nav3recipes.deeplink.basic.deeplinkutil.DeepLinkPattern
-import com.example.nav3recipes.deeplink.basic.deeplinkutil.DeepLinkRequest
-import com.example.nav3recipes.deeplink.basic.deeplinkutil.DeepLinkMatchResult
-import com.example.nav3recipes.deeplink.basic.deeplinkutil.KeyDecoder
+import com.example.nav3recipes.deeplink.basic.util.DeepLinkMatcher
+import com.example.nav3recipes.deeplink.basic.util.DeepLinkPattern
+import com.example.nav3recipes.deeplink.basic.util.DeepLinkRequest
+import com.example.nav3recipes.deeplink.basic.util.DeepLinkMatchResult
+import com.example.nav3recipes.deeplink.basic.util.KeyDecoder
 import com.example.nav3recipes.deeplink.basic.ui.EntryScreen
 import com.example.nav3recipes.deeplink.basic.ui.FriendsList
 import com.example.nav3recipes.deeplink.basic.ui.HomeKey

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
@@ -1,4 +1,4 @@
-package com.example.nav3recipes.deeplink.basic.deeplinkutil
+package com.example.nav3recipes.deeplink.basic.util
 
 import android.util.Log
 import androidx.navigation3.runtime.NavKey

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkPattern.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkPattern.kt
@@ -1,8 +1,7 @@
-package com.example.nav3recipes.deeplink.basic.deeplinkutil
+package com.example.nav3recipes.deeplink.basic.util
 
 import android.net.Uri
 import androidx.navigation3.runtime.NavKey
-import com.example.nav3recipes.deeplink.basic.ui.NavRecipeKey
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkRequest.kt.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkRequest.kt.kt
@@ -1,4 +1,4 @@
-package com.example.nav3recipes.deeplink.basic.deeplinkutil
+package com.example.nav3recipes.deeplink.basic.util
 
 import android.net.Uri
 

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/KeyDecoder.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/KeyDecoder.kt
@@ -1,4 +1,4 @@
-package com.example.nav3recipes.deeplink.basic.deeplinkutil
+package com.example.nav3recipes.deeplink.basic.util
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -8,7 +8,7 @@ import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
 
 /**
- * Decodes the list of arguments into a a backstack key
+ * Decodes the list of arguments into a a back stack key
  *
  * **IMPORTANT** This decoder assumes that all argument types are Primitives.
  */


### PR DESCRIPTION
Renamed `deeplink.basic.deeplinkutil` package to `deeplink.basic.util`.