### PR TITLE
Fix NPE in DeepLinkMatcher when URL contains extra query parameters

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
@@ -48,9 +48,12 @@ internal class DeepLinkMatcher<T : NavKey>(
         // match queries (if any)
         request.queries.forEach { query ->
             val name = query.key
-            val queryStringParser = deepLinkPattern.queryValueParsers[name]
+            // If the pattern does not define this query parameter, ignore it.
+            // This prevents a NullPointerException.
+            val queryStringParser = deepLinkPattern.queryValueParsers[name]?: return@forEach
+            
             val queryParsedValue = try {
-                queryStringParser!!.invoke(query.value)
+                queryStringParser.invoke(query.value)
             } catch (e: IllegalArgumentException) {
                 Log.e(TAG_LOG_ERROR, "Failed to parse query name:[$name] value:[${query.value}].", e)
                 return null


### PR DESCRIPTION
Hi,

I found a crash when using `DeepLinkMatcher`.

**The Problem:**
If the incoming deep link has query parameters that are not defined in the `DeepLinkPattern` (for example `?tab=1`), the app crashes with a `NullPointerException`.

**The Cause:**
The code tries to get a parser for the extra parameter, but `pattern.queryParamParsers[name]` returns null. The code then uses `!!` which causes the crash.

**The Fix:**
I added a check. If the parser is null (meaning the pattern doesn't care about this parameter), we simply skip it instead of crashing.

Thanks!