### PR TITLE
Validate scheme and authority in DeepLinkMatcher

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkMatcher.kt
@@ -15,7 +15,7 @@ internal class DeepLinkMatcher<T : NavKey>(
      */
     fun match(): DeepLinkMatchResult<T>? {
         if (request.uri.scheme != deepLinkPattern.uriPattern.scheme) return null
-        if (request.uri.authority != deepLinkPattern.uriPattern.authority) return null
+        if (!request.uri.authority.equals(deepLinkPattern.uriPattern.authority, ignoreCase = true)) return null
         if (request.pathSegments.size != deepLinkPattern.pathSegments.size) return null
         // exact match (url does not contain any arguments)
         if (request.uri == deepLinkPattern.uriPattern)


### PR DESCRIPTION
Hi,

I found another issue in `DeepLinkMatcher`.

**The Problem:**
The `match()` function currently only checks the path segments and query parameters. It ignores the `scheme` (e.g., `https` vs `http`) and the `authority` (host/domain).

This means a pattern defined as `https://example.com/home` would incorrectly match `http://wrong-site.com/home`.

**The Fix:**
I added checks at the start of the `match()` function to ensure the `scheme` and `authority` of the incoming request match the pattern exactly.