### PR TITLE
feat: Implement Recipe request #204

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,6 +138,10 @@
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
+            android:name=".multiplestacksandauthentication.MultipleStacksAndAuthenticationActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Nav3Recipes"/>
+        <activity
             android:name=".deeplink.basic.CreateDeepLinkActivity"
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes">

--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -64,6 +64,7 @@ import com.example.nav3recipes.scenes.listdetail.ListDetailActivity
 import com.example.nav3recipes.scenes.twopane.TwoPaneActivity
 import com.example.nav3recipes.ui.setEdgeToEdgeConfig
 import com.example.nav3recipes.deeplink.advanced.AdvancedCreateDeepLinkActivity
+import com.example.nav3recipes.multiplestacksandauthentication.MultipleStacksAndAuthenticationActivity
 
 /**
  * Activity to show all available recipes and allow users to launch each one.
@@ -97,6 +98,7 @@ private val recipes = listOf(
     Heading("Common use cases"),
     Recipe("Common UI", CommonUiActivity::class.java),
     Recipe("Multiple Stacks", MultipleStacksActivity::class.java),
+    Recipe("Multiple Stacks And Authentication", MultipleStacksAndAuthenticationActivity::class.java),
     Recipe("Conditional navigation", ConditionalActivity::class.java),
 
     Heading("Architecture"),

--- a/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/Content.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacksandauthentication
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.content.ContentGreen
+import com.example.nav3recipes.content.ContentMauve
+import com.example.nav3recipes.content.ContentOrange
+import com.example.nav3recipes.content.ContentPink
+import com.example.nav3recipes.content.ContentPurple
+import com.example.nav3recipes.content.ContentRed
+
+fun EntryProviderScope<NavKey>.rootSection(
+    navigator: Navigator,
+) {
+    entry<AuthenticationRoute> {
+        NavDisplay(
+            backStack = navigator.state.authenticationBackStack,
+            entryProvider = entryProvider {
+                authenticationSection(
+                    navigateToLogin = {
+                        navigator.navigate(AuthenticationRoute.LoginRoute)
+                    },
+                    navigateToRegister = {
+                        navigator.navigate(AuthenticationRoute.RegisterRoute)
+                    },
+                    onLoginClick = {
+                        navigator.navigate(ConnectedRoute)
+                    }
+                )
+            }
+        )
+    }
+
+    entry<ConnectedRoute> {
+        NavDisplay(
+            entries = navigator.state.toDecoratedEntries(
+                entryProvider = entryProvider {
+                    featureASection(onSubRouteClick = { navigator.navigate(ConnectedRoute.RouteA1) })
+                    featureBSection(onSubRouteClick = { navigator.navigate(ConnectedRoute.RouteB1) })
+                    featureCSection(onSubRouteClick = { navigator.navigate(ConnectedRoute.RouteC1) })
+                }
+            ),
+            onBack = { navigator.goBack() }
+        )
+    }
+}
+
+fun EntryProviderScope<NavKey>.authenticationSection(
+    navigateToLogin: () -> Unit,
+    navigateToRegister: () -> Unit,
+    onLoginClick: () -> Unit
+) {
+    entry<AuthenticationRoute.WelcomeRoute> {
+        ContentGreen("Welcome") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = navigateToLogin) {
+                    Text("Go to Login")
+                }
+                Button(onClick = navigateToRegister) {
+                    Text("Go to Register")
+                }
+            }
+        }
+    }
+    entry<AuthenticationRoute.LoginRoute> {
+        ContentPink("Login") {
+            Button(onClick = onLoginClick) {
+                Text("Login")
+            }
+        }
+    }
+    entry<AuthenticationRoute.RegisterRoute> {
+        ContentPurple("Register") {
+            Button(onClick = navigateToLogin) {
+                Text("Go to Login after registration")
+            }
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureASection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<ConnectedRoute.RouteA> {
+        ContentRed("Route A") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = onSubRouteClick) {
+                    Text("Go to A1")
+                }
+            }
+        }
+    }
+    entry<ConnectedRoute.RouteA1> {
+        ContentPink("Route A1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureBSection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<ConnectedRoute.RouteB> {
+        ContentGreen("Route B") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = onSubRouteClick) {
+                    Text("Go to B1")
+                }
+            }
+        }
+    }
+    entry<ConnectedRoute.RouteB1> {
+        ContentPurple("Route B1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}
+
+fun EntryProviderScope<NavKey>.featureCSection(
+    onSubRouteClick: () -> Unit,
+) {
+    entry<ConnectedRoute.RouteC> {
+        ContentMauve("Route C") {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Button(onClick = onSubRouteClick) {
+                    Text("Go to C1")
+                }
+            }
+        }
+    }
+    entry<ConnectedRoute.RouteC1> {
+        ContentOrange("Route C1") {
+            var count by rememberSaveable {
+                mutableIntStateOf(0)
+            }
+
+            Button(onClick = { count++ }) {
+                Text("Value: $count")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/MultipleStacksAndAuthenticationActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/MultipleStacksAndAuthenticationActivity.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacksandauthentication
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material.icons.filled.Face
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+sealed interface Root: NavKey
+
+sealed interface Authentication: NavKey
+
+@Serializable
+data object AuthenticationRoute : Root {
+    @Serializable
+    data object WelcomeRoute : Authentication
+
+    @Serializable
+    data object LoginRoute : Authentication
+
+    @Serializable
+    data object RegisterRoute : Authentication
+}
+
+sealed interface Connected: NavKey
+
+@Serializable
+data object ConnectedRoute : Root {
+    @Serializable
+    data object RouteA : Connected
+
+    @Serializable
+    data object RouteA1 : Connected
+
+    @Serializable
+    data object RouteB : Connected
+
+    @Serializable
+    data object RouteB1 : Connected
+
+    @Serializable
+    data object RouteC : Connected
+
+    @Serializable
+    data object RouteC1 : Connected
+}
+
+private val TOP_LEVEL_ROUTES = mapOf<NavKey, NavBarItem>(
+    ConnectedRoute.RouteA to NavBarItem(icon = Icons.Default.Home, description = "Route A"),
+    ConnectedRoute.RouteB to NavBarItem(icon = Icons.Default.Face, description = "Route B"),
+    ConnectedRoute.RouteC to NavBarItem(icon = Icons.Default.Camera, description = "Route C"),
+)
+
+data class NavBarItem(
+    val icon: ImageVector,
+    val description: String
+)
+
+class MultipleStacksAndAuthenticationActivity : ComponentActivity() {
+    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val navigationState = rememberNavigationState(
+                rootStartRoute = AuthenticationRoute,
+                authenticationStartRoute = AuthenticationRoute.WelcomeRoute,
+                topLevelStartRoute = ConnectedRoute.RouteA,
+                topLevelRoutes = TOP_LEVEL_ROUTES.keys
+            )
+
+            val navigator = remember { Navigator(navigationState) }
+
+            Scaffold(bottomBar = {
+                if (navigationState.currentRootDestination == ConnectedRoute) {
+                    NavigationBar {
+                        TOP_LEVEL_ROUTES.forEach { (key, value) ->
+                            val isSelected = key == navigationState.topLevelRoute
+                            NavigationBarItem(
+                                selected = isSelected,
+                                onClick = { navigator.navigate(key) },
+                                icon = {
+                                    Icon(
+                                        imageVector = value.icon,
+                                        contentDescription = value.description
+                                    )
+                                },
+                                label = { Text(value.description) }
+                            )
+                        }
+                    }
+                }
+            }) {
+                NavDisplay(
+                    backStack = navigationState.rootBackStack,
+                    entryProvider = entryProvider {
+                        rootSection(
+                            navigator = navigator
+                        )
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/NavigationState.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/NavigationState.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacksandauthentication
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.toMutableStateList
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.runtime.serialization.NavKeySerializer
+import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
+
+/**
+ * Create a navigation state that persists config changes and process death.
+ *
+ * @param topLevelStartRoute - The top level route to start on. This should also be in `topLevelRoutes`.
+ * @param topLevelRoutes - The top level routes in the app.
+ */
+@Composable
+fun rememberNavigationState(
+    rootStartRoute: NavKey,
+    authenticationStartRoute: NavKey,
+    topLevelStartRoute: NavKey,
+    topLevelRoutes: Set<NavKey>
+): NavigationState {
+
+    val rootBackStack = rememberNavBackStack(rootStartRoute)
+
+    val authenticationBackStack = rememberNavBackStack(authenticationStartRoute)
+
+    val topLevelRoute = rememberSerializable(
+        topLevelStartRoute, topLevelRoutes,
+        serializer = MutableStateSerializer(NavKeySerializer())
+    ) {
+        mutableStateOf(topLevelStartRoute)
+    }
+
+    // Create a back stack for each top level route.
+    val backStacks = topLevelRoutes.associateWith { key -> rememberNavBackStack(key) }
+
+    return remember(topLevelStartRoute, topLevelRoutes) {
+        NavigationState(
+            rootStartRoute = rootStartRoute,
+            rootBackStack = rootBackStack,
+            authenticationBackStack = authenticationBackStack,
+            topLevelStartRoute = topLevelStartRoute,
+            topLevelRoute = topLevelRoute,
+            backStacks = backStacks
+        )
+    }
+}
+
+/**
+ * State holder for navigation state. This class does not modify its own state. It is designed
+ * to be modified using the `Navigator` class.
+ *
+ * @param topLevelStartRoute - the start route. The user will exit the app through this route.
+ * @param topLevelRoute - the state object that backs the top level route.
+ * @param backStacks - the back stacks for each top level route.
+ */
+class NavigationState(
+    val rootStartRoute: NavKey,
+    val rootBackStack: NavBackStack<NavKey>,
+    val authenticationBackStack: NavBackStack<NavKey>,
+    val topLevelStartRoute: NavKey,
+    topLevelRoute: MutableState<NavKey>,
+    val backStacks: Map<NavKey, NavBackStack<NavKey>>
+) {
+
+    /**
+     * The top level route.
+     */
+    var topLevelRoute: NavKey by topLevelRoute
+
+    /**
+     * The current root destination (nav graph level, e.g., WelcomeNavGraph or HomeNavGraph).
+     */
+    val currentRootDestination: NavKey
+        get() = rootBackStack.lastOrNull() ?: rootStartRoute
+
+    /**
+     * Convert the navigation state into `NavEntry`s that have been decorated with a
+     * `SaveableStateHolder`.
+     *
+     * @param entryProvider - the entry provider used to convert the keys in the
+     * back stacks to `NavEntry`s.
+     */
+    @Composable
+    fun toDecoratedEntries(
+        entryProvider: (NavKey) -> NavEntry<NavKey>
+    ): SnapshotStateList<NavEntry<NavKey>> {
+
+        // For each back stack, create a `SaveableStateHolder` decorator and use it to decorate
+        // the entries from that stack. When backStacks changes, `rememberDecoratedNavEntries` will
+        // be recomposed and a new list of decorated entries is returned.
+        val decoratedEntries = backStacks.mapValues { (_, stack) ->
+            val decorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+            )
+            rememberDecoratedNavEntries(
+                backStack = stack,
+                entryDecorators = decorators,
+                entryProvider = entryProvider
+            )
+        }
+
+        // Only return the entries for the stacks that are currently in use.
+        return getTopLevelRoutesInUse()
+            .flatMap { decoratedEntries[it] ?: emptyList() }
+            .toMutableStateList()
+    }
+
+    /**
+     * Get the top level routes that are currently in use. The start route is always the first route
+     * in the list. This means the user will always exit the app through the starting route
+     * ("exit through home" pattern). The list will contain a maximum of one other route. This is a
+     * design decision. In your app, you may wish to allow more than two top level routes to be
+     * active.
+     *
+     * Note that even if a top level route is not in use its state is still retained.
+     *
+     * @return the current top level routes that are in use.
+     */
+    private fun getTopLevelRoutesInUse() : List<NavKey> =
+		if (topLevelRoute == topLevelStartRoute) {
+            listOf(topLevelStartRoute)
+        } else {
+            listOf(topLevelStartRoute, topLevelRoute)
+        }
+}

--- a/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/Navigator.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/Navigator.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.multiplestacksandauthentication
+
+import androidx.navigation3.runtime.NavKey
+
+/**
+ * Handles navigation events (forward and back) by updating the navigation state.
+ */
+class Navigator(val state: NavigationState) {
+
+    /**
+     * Navigate to a route. Handles navigation within both Authentication and Connected graphs,
+     * as well as transitions between them.
+     */
+    fun navigate(route: NavKey) {
+        when (route) {
+            is Root -> {
+                // If transitioning from Authentication, update root backstack first
+                if (state.currentRootDestination == AuthenticationRoute) {
+                    state.rootBackStack.removeLastOrNull()
+                    state.rootBackStack.add(ConnectedRoute)
+                }
+            }
+
+            // Navigation within Authentication graph
+            is Authentication -> {
+                state.authenticationBackStack.add(route)
+            }
+
+            // Navigation within Connected graph (or transitioning to it from Authentication)
+            is Connected -> {
+                if (route in state.backStacks.keys) {
+                    // This is a top level route, just switch to it
+                    state.topLevelRoute = route
+                } else {
+                    state.backStacks[state.topLevelRoute]?.add(route)
+                }
+            }
+        }
+    }
+
+    /**
+     * Go back. Handles back navigation within both Authentication and Connected graphs.
+     */
+    fun goBack() {
+        when (state.currentRootDestination) {
+            AuthenticationRoute -> {
+                state.authenticationBackStack.removeLastOrNull()
+            }
+
+            ConnectedRoute -> {
+                val currentStack = state.backStacks[state.topLevelRoute]
+                    ?: error("Stack for ${state.topLevelRoute} not found")
+                val currentRoute = currentStack.last()
+
+                // If we're at the base of the current route, go back to the start route stack.
+                if (currentRoute == state.topLevelRoute) {
+                    state.topLevelRoute = state.topLevelStartRoute
+                } else {
+                    currentStack.removeLastOrNull()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/README.md
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacksandauthentication/README.md
@@ -1,0 +1,23 @@
+# Multiple back stacks and authentication recipe #
+
+This recipe builds upon the multiple back stacks recipe, adding an initial authentication section. 
+
+The app starts with an authentication flow with three routes: `Welcome`, `Login` and `Register`. Upon successful authentication, the app navigates to the "connected" part of the application.
+
+The connected section has three top level routes: `RouteA`, `RouteB` and `RouteC`. These routes have sub routes `RouteA1`, `RouteB1` and `RouteC1` respectively. The content for the sub routes is a counter that can be used to verify state retention through configuration changes and process death.
+
+The app's navigation state is held in the `NavigationState` class. The state itself is created using `rememberNavigationState`. 
+
+Navigation events are handled by the `Navigator`. It updates the navigation state.
+
+The navigation state is converted into `NavEntry`s with `NavigationState.toDecoratedEntries`. These entries are then displayed by `NavDisplay`. 
+
+Key behaviors: 
+
+- The authentication flow is only shown when the user is not authenticated. Once authenticated, the user cannot navigate back to the authentication flow.
+- This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are _always_ in the list of entries. 
+- Navigating to a top level route that is not the starting route _replaces_ the other entries. For example, navigating A->B->C would result in entries for A+C, B's entries are removed. 
+
+Important implementation details: 
+
+- Each top level route has its own `SaveableStateHolderNavEntryDecorator`. This is the object responsible for managing the state for the entries in its back stack. 


### PR DESCRIPTION
Recipe request #204 builds upon the Multiple stacks recipe but adds the notion of an authentication flow before. This requires splitting the two flows into their own NavDisplay to handle the respective behaviour for each.

Some minor changes to note compared to the Multiple stacks recipe:

- Add the notion of a `Root` and `Authentication` backstacks (as well as their start routes)
    - The `Root` backstack will handle navigating between the two flows (namely `Authentication` and `Connected`)
    - The `Authentication` backstack will handle the navigation within the Authentication flow (between the Welcome, Login and Register screens)
- Update the `Navigator` functions to handle the distinctions between navigating within each graph

This is in no way a final PR (unless maintainers consider it up to standard compared to the other recipes) and I am happy to make changes or let others make changes if necessary.