### PR TITLE
Wrap navigation actions with `dropUnlessResumed`

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.animations.AnimatedActivity
 import com.example.nav3recipes.basic.BasicActivity
 import com.example.nav3recipes.basicdsl.BasicDslActivity
@@ -153,9 +154,9 @@ class RecipePickerActivity : ComponentActivity() {
                     is Recipe -> {
                         ListItem(
                             headlineContent = { Text(item.name) },
-                            modifier = Modifier.clickable {
+                            modifier = Modifier.clickable(onClick = dropUnlessResumed {
                                 item.start()
-                            }
+                            })
                         )
                     }
                     is Heading -> {

--- a/app/src/main/java/com/example/nav3recipes/animations/AnimatedActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/animations/AnimatedActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -50,14 +51,14 @@ class AnimatedActivity : ComponentActivity() {
                 entryProvider = entryProvider {
                     entry<ScreenA> {
                         ContentOrange("This is Screen A") {
-                            Button(onClick = { backStack.add(ScreenB) }) {
+                            Button(onClick = dropUnlessResumed { backStack.add(ScreenB) }) {
                                 Text("Go to Screen B")
                             }
                         }
                     }
                     entry<ScreenB> {
                         ContentMauve("This is Screen B") {
-                            Button(onClick = { backStack.add(ScreenC) }) {
+                            Button(onClick = dropUnlessResumed { backStack.add(ScreenC) }) {
                                 Text("Go to Screen C")
                             }
                         }

--- a/app/src/main/java/com/example/nav3recipes/basic/BasicActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/basic/BasicActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import com.example.nav3recipes.content.ContentBlue
@@ -48,7 +49,7 @@ class BasicActivity : ComponentActivity() {
                     when (key) {
                         is RouteA -> NavEntry(key) {
                             ContentGreen("Welcome to Nav3") {
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.add(RouteB("123"))
                                 }) {
                                     Text("Click to navigate")

--- a/app/src/main/java/com/example/nav3recipes/basicdsl/BasicDslActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/basicdsl/BasicDslActivity.kt
@@ -21,6 +21,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -50,7 +51,7 @@ class BasicDslActivity : ComponentActivity() {
                 entryProvider = entryProvider {
                     entry<RouteA> {
                         ContentGreen("Welcome to Nav3") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(RouteB("123"))
                             }) {
                                 Text("Click to navigate")

--- a/app/src/main/java/com/example/nav3recipes/basicsaveable/BasicSaveableActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/basicsaveable/BasicSaveableActivity.kt
@@ -21,6 +21,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -51,7 +52,7 @@ class BasicSaveableActivity : ComponentActivity() {
                     when (key) {
                         is RouteA -> NavEntry(key) {
                             ContentGreen("Welcome to Nav3") {
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.add(RouteB("123"))
                                 }) {
                                     Text("Click to navigate")

--- a/app/src/main/java/com/example/nav3recipes/bottomsheet/BottomSheetActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/bottomsheet/BottomSheetActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -59,7 +60,7 @@ class BottomSheetActivity : ComponentActivity() {
                 entryProvider = entryProvider {
                     entry<RouteA> {
                         ContentGreen("Welcome to Nav3") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(RouteB("123"))
                             }) {
                                 Text("Click to open bottom sheet")

--- a/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/commonui/CommonUiActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
 import com.example.nav3recipes.content.ContentBlue
@@ -92,7 +93,9 @@ class CommonUiActivity : ComponentActivity() {
                         }
                         entry<ChatList>{
                             ContentGreen("Chat list screen"){
-                                Button(onClick = { topLevelBackStack.add(ChatDetail) }) {
+                                Button(onClick = dropUnlessResumed {
+                                    topLevelBackStack.add(ChatDetail)
+                                }) {
                                     Text("Go to conversation")
                                 }
                             }

--- a/app/src/main/java/com/example/nav3recipes/conditional/ConditionalActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/conditional/ConditionalActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -100,10 +101,10 @@ class ConditionalActivity : ComponentActivity() {
                     entry<Home> {
                         ContentGreen("Welcome to Nav3. Logged in? ${isLoggedIn}") {
                             Column {
-                                Button(onClick = { navigator.navigate(Profile) }) {
+                                Button(onClick = dropUnlessResumed { navigator.navigate(Profile) }) {
                                     Text("Profile")
                                 }
-                                Button(onClick = { navigator.navigate(Login()) }) {
+                                Button(onClick = dropUnlessResumed { navigator.navigate(Login()) }) {
                                     Text("Login")
                                 }
                             }
@@ -111,7 +112,7 @@ class ConditionalActivity : ComponentActivity() {
                     }
                     entry<Profile> {
                         ContentBlue("Profile screen (only accessible once logged in)") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 isLoggedIn = false
                                 navigator.navigate(Home)
                             }) {
@@ -121,7 +122,7 @@ class ConditionalActivity : ComponentActivity() {
                     }
                     entry<Login> { key ->
                         ContentYellow("Login screen. Logged in? $isLoggedIn") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 isLoggedIn = true
                                 key.redirectToKey?.let { targetKey ->
                                     backStack.remove(key)

--- a/app/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedCreateDeepLinkActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedCreateDeepLinkActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.deeplink.common.EntryScreen
 import com.example.nav3recipes.deeplink.common.LIST_FIRST_NAMES
 import com.example.nav3recipes.deeplink.common.LIST_LOCATIONS
@@ -86,7 +87,7 @@ class AdvancedCreateDeepLinkActivity: ComponentActivity() {
                 TextContent(intentString)
 
                 // deeplink to target
-                PaddedButton("Deeplink Away!") {
+                PaddedButton("Deeplink Away!", onClick = dropUnlessResumed {
                     val intent = Intent().apply {
                         data = finalUrl.toUri()
                         action = Intent.ACTION_VIEW
@@ -96,7 +97,7 @@ class AdvancedCreateDeepLinkActivity: ComponentActivity() {
                     }
 
                     startActivity(intent)
-                }
+                })
             }
         }
     }

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/CreateDeepLinkActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/CreateDeepLinkActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.deeplink.common.PaddedButton
 import com.example.nav3recipes.deeplink.common.EMPTY
 import com.example.nav3recipes.deeplink.common.EntryScreen
@@ -149,7 +150,7 @@ class CreateDeepLinkActivity : ComponentActivity() {
                 val finalUrl = "${PATH_BASE}/${selectedPath.value}$arguments"
                 TextContent("Final url:\n$finalUrl")
                 // deeplink to target
-                PaddedButton("Deeplink Away!") {
+                PaddedButton("Deeplink Away!", onClick = dropUnlessResumed {
                     val intent = Intent(
                         this@CreateDeepLinkActivity,
                         MainActivity::class.java
@@ -157,7 +158,7 @@ class CreateDeepLinkActivity : ComponentActivity() {
                     // start activity with the url
                     intent.data = finalUrl.toUri()
                     startActivity(intent)
-                }
+                })
             }
         }
     }

--- a/app/src/main/java/com/example/nav3recipes/dialog/DialogActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/dialog/DialogActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -59,7 +60,7 @@ class DialogActivity : ComponentActivity() {
                 entryProvider = entryProvider {
                     entry<RouteA> {
                         ContentGreen("Welcome to Nav3") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(RouteB("123"))
                             }) {
                                 Text("Click to open dialog")

--- a/app/src/main/java/com/example/nav3recipes/material/listdetail/MaterialListDetailActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/material/listdetail/MaterialListDetailActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneSt
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -83,7 +84,7 @@ class MaterialListDetailActivity : ComponentActivity() {
                         )
                     ) {
                         ContentRed("Welcome to Nav3") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(ConversationDetail("ABC"))
                             }) {
                                 Text("View conversation")
@@ -95,7 +96,7 @@ class MaterialListDetailActivity : ComponentActivity() {
                     ) { conversation ->
                         ContentBlue("Conversation ${conversation.id} ") {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.add(Profile)
                                 }) {
                                     Text("View profile")

--- a/app/src/main/java/com/example/nav3recipes/material/supportingpane/MaterialSupportingPaneActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/material/supportingpane/MaterialSupportingPaneActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.adaptive.navigation3.rememberSupportingPaneSce
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -85,7 +86,7 @@ class MaterialSupportingPaneActivity : ComponentActivity() {
                         metadata = SupportingPaneSceneStrategy.mainPane()
                     ) {
                         ContentRed("Video content") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(RelatedVideos)
                             }) {
                                 Text("View related videos")
@@ -97,7 +98,7 @@ class MaterialSupportingPaneActivity : ComponentActivity() {
                     ) {
                         ContentBlue("Related videos") {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.add(Profile)
                                 }) {
                                     Text("View profile")

--- a/app/src/main/java/com/example/nav3recipes/migration/content/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/migration/content/Content.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.content.ContentGreen
 import com.example.nav3recipes.content.ContentMauve
 import com.example.nav3recipes.content.ContentPink
@@ -32,10 +33,10 @@ import com.example.nav3recipes.content.ContentRed
 fun ScreenA(onSubRouteClick: () -> Unit, onDialogClick: () -> Unit) {
     ContentRed("Route A title") {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Button(onClick = onSubRouteClick) {
+            Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
                 Text("Go to A1")
             }
-            Button(onClick = onDialogClick) {
+            Button(onClick = dropUnlessResumed(block = onDialogClick)) {
                 Text("Open dialog D")
             }
         }
@@ -54,10 +55,10 @@ fun ScreenB(
 ) {
     ContentGreen("Route B title") {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Button(onClick = { onDetailClick("ABC") }) {
+            Button(onClick = dropUnlessResumed { onDetailClick("ABC") }) {
                 Text("Go to B1")
             }
-            Button(onClick = onDialogClick) {
+            Button(onClick = dropUnlessResumed(block = onDialogClick)) {
                 Text("Open dialog D")
             }
         }
@@ -73,7 +74,7 @@ fun ScreenB1(id: String) {
 fun ScreenC(onDialogClick: () -> Unit) {
     ContentMauve("Route C title") {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Button(onClick = onDialogClick) {
+            Button(onClick = dropUnlessResumed(block = onDialogClick)) {
                 Text("Open dialog D")
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/modular/hilt/ConversationModule.kt
+++ b/app/src/main/java/com/example/nav3recipes/modular/hilt/ConversationModule.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.ui.theme.colors
 import dagger.Module
 import dagger.Provides
@@ -70,7 +71,9 @@ private fun ConversationListScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = { onConversationClicked(conversationDetail) }),
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
                 headlineContent = {
                     Text(
                         text = "Conversation $conversationId",
@@ -105,7 +108,7 @@ private fun ConversationDetailScreen(
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onProfileClicked) {
+        Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
             Text("View Profile")
         }
     }

--- a/app/src/main/java/com/example/nav3recipes/modular/koin/ConversationModule.kt
+++ b/app/src/main/java/com/example/nav3recipes/modular/koin/ConversationModule.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.ui.theme.colors
 import org.koin.androidx.scope.dsl.activityRetainedScope
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -66,7 +67,9 @@ private fun ConversationListScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = { onConversationClicked(conversationDetail) }),
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
                 headlineContent = {
                     Text(
                         text = "Conversation $conversationId",
@@ -101,7 +104,7 @@ private fun ConversationDetailScreen(
             color = MaterialTheme.colorScheme.onSurface
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onProfileClicked) {
+        Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
             Text("View Profile")
         }
     }

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.example.nav3recipes.content.ContentGreen
@@ -39,7 +40,7 @@ fun EntryProviderScope<NavKey>.featureASection(
     entry<RouteA> {
         ContentRed("Route A") {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = onSubRouteClick) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
                     Text("Go to A1")
                 }
             }
@@ -51,7 +52,7 @@ fun EntryProviderScope<NavKey>.featureASection(
                 mutableIntStateOf(0)
             }
 
-            Button(onClick = { count++ }) {
+            Button(onClick = dropUnlessResumed { count++ }) {
                 Text("Value: $count")
             }
         }
@@ -64,7 +65,7 @@ fun EntryProviderScope<NavKey>.featureBSection(
     entry<RouteB> {
         ContentGreen("Route B") {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = onSubRouteClick) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
                     Text("Go to B1")
                 }
             }
@@ -75,7 +76,7 @@ fun EntryProviderScope<NavKey>.featureBSection(
             var count by rememberSaveable {
                 mutableIntStateOf(0)
             }
-            Button(onClick = { count++ }) {
+            Button(onClick = dropUnlessResumed { count++ }) {
                 Text("Value: $count")
             }
         }
@@ -88,7 +89,7 @@ fun EntryProviderScope<NavKey>.featureCSection(
     entry<RouteC> {
         ContentMauve("Route C") {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = onSubRouteClick) {
+                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
                     Text("Go to C1")
                 }
             }
@@ -100,7 +101,7 @@ fun EntryProviderScope<NavKey>.featureCSection(
                 mutableIntStateOf(0)
             }
 
-            Button(onClick = { count++ }) {
+            Button(onClick = dropUnlessResumed { count++ }) {
                 Text("Value: $count")
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic/BasicViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/basic/BasicViewModelsActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
@@ -64,7 +65,7 @@ class BasicViewModelsActivity : ComponentActivity() {
                         ContentGreen("Welcome to Nav3") {
                             LazyColumn {
                                 items(10) { i ->
-                                    Button(onClick = {
+                                    Button(onClick = dropUnlessResumed {
                                         backStack.add(RouteB("$i"))
                                     }) {
                                         Text("$i")

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt/HiltViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/hilt/HiltViewModelsActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
@@ -70,7 +71,7 @@ class HiltViewModelsActivity : ComponentActivity() {
                         ContentGreen("Welcome to Nav3") {
                             LazyColumn {
                                 items(10) { i ->
-                                    Button(onClick = {
+                                    Button(onClick = dropUnlessResumed {
                                         backStack.add(RouteB("$i"))
                                     }) {
                                         Text("$i")

--- a/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/passingarguments/viewmodels/koin/KoinViewModelsActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
@@ -64,7 +65,7 @@ class KoinViewModelsActivity : ComponentActivity() {
                             ContentGreen("Welcome to Nav3") {
                                 LazyColumn {
                                     items(10) { i ->
-                                        Button(onClick = {
+                                        Button(onClick = dropUnlessResumed {
                                             backStack.add(RouteB("$i"))
                                         }) {
                                             Text("$i")

--- a/app/src/main/java/com/example/nav3recipes/results/common/ScreenContent.kt
+++ b/app/src/main/java/com/example/nav3recipes/results/common/ScreenContent.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.content.ContentBlue
 import com.example.nav3recipes.content.ContentGreen
 
@@ -40,7 +41,7 @@ fun HomeScreen(
         }
 
         Spacer(Modifier.height(16.dp))
-        Button(onClick = onNext) {
+        Button(onClick = dropUnlessResumed(block = onNext)) {
             Text("Tell us about yourself")
         }
     }
@@ -65,7 +66,7 @@ fun PersonDetailsScreen(
         )
 
         Button(
-            onClick = {
+            onClick = dropUnlessResumed {
                 val person = Person(
                     name = nameTextState.text.toString(),
                     favoriteColor = favoriteColorTextState.text.toString()

--- a/app/src/main/java/com/example/nav3recipes/scenes/listdetail/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/scenes/listdetail/Content.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.ui.theme.colors
 
 @Composable
@@ -59,7 +60,9 @@ fun ConversationListScreen(
             ListItem(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable(onClick = { onConversationClicked(conversationDetail) }),
+                    .clickable(onClick = dropUnlessResumed {
+                        onConversationClicked(conversationDetail)
+                    }),
                 headlineContent = {
                     Text(
                         text = "Conversation $conversationId",
@@ -110,7 +113,7 @@ fun ConversationDetailScreen(
                 color = MaterialTheme.colorScheme.onSurface
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = onProfileClicked) {
+            Button(onClick = dropUnlessResumed(block = onProfileClicked)) {
                 Text("View Profile")
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/scenes/twopane/TwoPaneActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/scenes/twopane/TwoPaneActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -78,12 +79,12 @@ class TwoPaneActivity : ComponentActivity() {
                             Modifier.background(colors[product.id % colors.size])
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.addProductRoute(product.id + 1)
                                 }) {
                                     Text("View the next product")
                                 }
-                                Button(onClick = {
+                                Button(onClick = dropUnlessResumed {
                                     backStack.add(Profile)
                                 }) {
                                     Text("View profile")

--- a/app/src/main/java/com/example/nav3recipes/sharedviewmodel/SharedViewModelActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/sharedviewmodel/SharedViewModelActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -71,10 +72,10 @@ class SharedViewModelActivity : ComponentActivity() {
                         val viewModel = viewModel(modelClass = CounterViewModel::class)
 
                         ContentRed("Parent screen") {
-                            Button(onClick = { viewModel.count++ }) {
+                            Button(onClick = dropUnlessResumed { viewModel.count++ }) {
                                 Text("Count: ${viewModel.count}")
                             }
-                            Button(onClick = { backStack.add(ChildScreen) }) {
+                            Button(onClick = dropUnlessResumed { backStack.add(ChildScreen) }) {
                                 Text("View child screen")
                             }
                         }
@@ -88,10 +89,10 @@ class SharedViewModelActivity : ComponentActivity() {
                         val parentViewModel = viewModel(modelClass = CounterViewModel::class)
 
                         ContentBlue("Child screen") {
-                            Button(onClick = { parentViewModel.count++ }) {
+                            Button(onClick = dropUnlessResumed { parentViewModel.count++ }) {
                                 Text("Parent count: ${parentViewModel.count}")
                             }
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 backStack.add(StandaloneScreen)
                             }) {
                                 Text("View standalone screen")
@@ -102,7 +103,7 @@ class SharedViewModelActivity : ComponentActivity() {
                         val viewModel = viewModel(modelClass = CounterViewModel::class)
 
                         ContentGreen("Standalone screen") {
-                            Button(onClick = {
+                            Button(onClick = dropUnlessResumed {
                                 viewModel.count++
                             }) {
                                 Text("Count: ${viewModel.count}")


### PR DESCRIPTION
This commit updates `onClick` handlers across the sample app to use `androidx.lifecycle.compose.dropUnlessResumed`. This prevents multiple navigation events from being triggered simultaneously and ensures actions only occur when the lifecycle is in the `RESUMED` state.

Changes include:
*   Wrapping `Button` and `clickable` actions in Basic, Material, and Scene recipes.
*   Applying the fix to DeepLink, ViewModel, and Modular (Hilt/Koin) samples.
*   Ensuring consistent navigation behavior across all Nav3 recipes to avoid double-tap issues.

Fixes #107