### PR TITLE
Fix crash when deep link URI pattern contains static query parameters

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkPattern.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkPattern.kt
@@ -86,13 +86,11 @@ internal class DeepLinkPattern<T : NavKey>(
     val queryValueParsers: Map<String, TypeParser> = buildMap {
         uriPattern.queryParameterNames.forEach { paramName ->
             val elementIndex = serializer.descriptor.getElementIndex(paramName)
-            if (elementIndex == CompositeDecoder.UNKNOWN_NAME) {
-                throw IllegalArgumentException(
-                    "Query parameter '$paramName' defined in the DeepLink $uriPattern does not exist in the Serializable class '${serializer.descriptor.serialName}'."
-                )
+            // Ignore static query parameters that are not in the Serializable class
+            if (elementIndex != CompositeDecoder.UNKNOWN_NAME) {
+                val elementDescriptor = serializer.descriptor.getElementDescriptor(elementIndex)
+                this[paramName] = getTypeParser(elementDescriptor.kind)
             }
-            val elementDescriptor = serializer.descriptor.getElementDescriptor(elementIndex)
-            this[paramName] = getTypeParser(elementDescriptor.kind)
         }
     }
 


### PR DESCRIPTION
**Problem:**
Currently, if a deep link `uriPattern` contains a static query parameter (for example: `app://users?public_only=true`), the app will crash with an `IllegalArgumentException` if `public_only` is not defined as a property in the `@Serializable` route class. 

Deep links often use static query parameters for routing, so we shouldn't force developers to add unused properties to their data classes just to prevent a crash.

**Solution:**
Instead of throwing an exception, we can safely ignore the query parameter if `elementIndex == CompositeDecoder.UNKNOWN_NAME`. This allows the URI to match successfully without crashing.