### PR TITLE
Try to access query parameters only if its hierarchical URI

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkRequest.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/util/DeepLinkRequest.kt
@@ -19,8 +19,10 @@ internal class DeepLinkRequest(
      * A map of query name to query value
      */
     val queries = buildMap {
-        uri.queryParameterNames.forEach { argName ->
-            this[argName] = uri.getQueryParameter(argName)!!
+        if (uri.isHierarchical) {
+            uri.queryParameterNames.forEach { argName ->
+                this[argName] = uri.getQueryParameter(argName)!!
+            }
         }
     }
 


### PR DESCRIPTION
Non hierarchical  URI(any URI without // after scheme name) results in crash now with following error: 
Exception java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
  at android.net.Uri.getQueryParameterNames (Uri.java:1605)