### PR TITLE
Update dependencies, including AGP 8.13.1 -> 9.1.0

### DIFF
--- a/advanceddeeplinkapp/build.gradle.kts
+++ b/advanceddeeplinkapp/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
 }
@@ -31,9 +30,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
     }
     buildFeatures {
         compose = true

--- a/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedDeeplinkAppActivity.kt
+++ b/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedDeeplinkAppActivity.kt
@@ -24,10 +24,10 @@ import androidx.navigation3.ui.NavDisplay
 import com.example.nav3recipes.deeplink.advanced.util.buildBackStack
 import com.example.nav3recipes.deeplink.advanced.util.navigateUp
 import com.example.nav3recipes.deeplink.advanced.util.toKey
-import com.example.nav3recipes.deeplink.common.EntryScreen
-import com.example.nav3recipes.deeplink.common.FriendsList
-import com.example.nav3recipes.deeplink.common.LIST_USERS
-import com.example.nav3recipes.deeplink.common.PaddedButton
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.FriendsList
+import com.example.nav3recipes.common.deeplink.LIST_USERS
+import com.example.nav3recipes.common.deeplink.PaddedButton
 
 class AdvancedDeeplinkAppActivity: ComponentActivity() {
 

--- a/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/NavRecipeKey.kt
+++ b/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/NavRecipeKey.kt
@@ -1,7 +1,7 @@
 package com.example.nav3recipes.deeplink.advanced
 
 import androidx.navigation3.runtime.NavKey
-import com.example.nav3recipes.deeplink.common.User
+import com.example.nav3recipes.common.deeplink.User
 import kotlinx.serialization.Serializable
 import androidx.navigation3.runtime.NavBackStack
 import com.example.nav3recipes.deeplink.advanced.util.navigateUp

--- a/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/util/DeepLinkBackStackUtil.kt
+++ b/advanceddeeplinkapp/src/main/java/com/example/nav3recipes/deeplink/advanced/util/DeepLinkBackStackUtil.kt
@@ -14,7 +14,7 @@ import com.example.nav3recipes.deeplink.advanced.Home
 import com.example.nav3recipes.deeplink.advanced.NavDeepLinkRecipeKey
 import com.example.nav3recipes.deeplink.advanced.UserDetail
 import com.example.nav3recipes.deeplink.advanced.Users
-import com.example.nav3recipes.deeplink.common.LIST_USERS
+import com.example.nav3recipes.common.deeplink.LIST_USERS
 
 /**
  * A function that build a synthetic backStack.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,6 @@
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -30,7 +29,7 @@ android {
     defaultConfig {
         applicationId = "com.example.nav3recipes"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 
@@ -49,9 +48,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = "11"
     }
     buildFeatures {
         compose = true

--- a/app/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedCreateDeepLinkActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/advanced/AdvancedCreateDeepLinkActivity.kt
@@ -10,12 +10,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.dropUnlessResumed
-import com.example.nav3recipes.deeplink.common.EntryScreen
-import com.example.nav3recipes.deeplink.common.LIST_FIRST_NAMES
-import com.example.nav3recipes.deeplink.common.LIST_LOCATIONS
-import com.example.nav3recipes.deeplink.common.MenuDropDown
-import com.example.nav3recipes.deeplink.common.PaddedButton
-import com.example.nav3recipes.deeplink.common.TextContent
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.LIST_FIRST_NAMES
+import com.example.nav3recipes.common.deeplink.LIST_LOCATIONS
+import com.example.nav3recipes.common.deeplink.MenuDropDown
+import com.example.nav3recipes.common.deeplink.PaddedButton
+import com.example.nav3recipes.common.deeplink.TextContent
 
 internal const val ADVANCED_PATH_BASE = "https://www.nav3deeplink.com"
 

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/CreateDeepLinkActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/CreateDeepLinkActivity.kt
@@ -12,24 +12,24 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.dropUnlessResumed
-import com.example.nav3recipes.deeplink.common.PaddedButton
-import com.example.nav3recipes.deeplink.common.EMPTY
-import com.example.nav3recipes.deeplink.common.EntryScreen
-import com.example.nav3recipes.deeplink.common.FIRST_NAME_JOHN
-import com.example.nav3recipes.deeplink.common.FIRST_NAME_JULIE
-import com.example.nav3recipes.deeplink.common.FIRST_NAME_MARY
-import com.example.nav3recipes.deeplink.common.FIRST_NAME_TOM
-import com.example.nav3recipes.deeplink.common.LOCATION_BC
-import com.example.nav3recipes.deeplink.common.LOCATION_BR
-import com.example.nav3recipes.deeplink.common.LOCATION_CA
-import com.example.nav3recipes.deeplink.common.LOCATION_US
-import com.example.nav3recipes.deeplink.common.MenuDropDown
-import com.example.nav3recipes.deeplink.common.MenuTextInput
+import com.example.nav3recipes.common.deeplink.PaddedButton
+import com.example.nav3recipes.common.deeplink.EMPTY
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.FIRST_NAME_JOHN
+import com.example.nav3recipes.common.deeplink.FIRST_NAME_JULIE
+import com.example.nav3recipes.common.deeplink.FIRST_NAME_MARY
+import com.example.nav3recipes.common.deeplink.FIRST_NAME_TOM
+import com.example.nav3recipes.common.deeplink.LOCATION_BC
+import com.example.nav3recipes.common.deeplink.LOCATION_BR
+import com.example.nav3recipes.common.deeplink.LOCATION_CA
+import com.example.nav3recipes.common.deeplink.LOCATION_US
+import com.example.nav3recipes.common.deeplink.MenuDropDown
+import com.example.nav3recipes.common.deeplink.MenuTextInput
 import com.example.nav3recipes.deeplink.basic.ui.PATH_BASE
 import com.example.nav3recipes.deeplink.basic.ui.PATH_INCLUDE
 import com.example.nav3recipes.deeplink.basic.ui.PATH_SEARCH
 import com.example.nav3recipes.deeplink.basic.ui.STRING_LITERAL_HOME
-import com.example.nav3recipes.deeplink.common.TextContent
+import com.example.nav3recipes.common.deeplink.TextContent
 
 /**
  * This activity allows the user to create a deep link and make a request with it.
@@ -189,5 +189,4 @@ private val MENU_OPTIONS_SEARCH = mapOf(
 )
 
 private val MENU_LABELS_SEARCH = listOf(SearchKey::ageMin.name, SearchKey::ageMax.name)
-
 

--- a/app/src/main/java/com/example/nav3recipes/deeplink/basic/MainActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/basic/MainActivity.kt
@@ -15,13 +15,13 @@ import com.example.nav3recipes.deeplink.basic.util.DeepLinkPattern
 import com.example.nav3recipes.deeplink.basic.util.DeepLinkRequest
 import com.example.nav3recipes.deeplink.basic.util.DeepLinkMatchResult
 import com.example.nav3recipes.deeplink.basic.util.KeyDecoder
-import com.example.nav3recipes.deeplink.common.TextContent
+import com.example.nav3recipes.common.deeplink.TextContent
 import com.example.nav3recipes.deeplink.basic.ui.URL_HOME_EXACT
 import com.example.nav3recipes.deeplink.basic.ui.URL_SEARCH
 import com.example.nav3recipes.deeplink.basic.ui.URL_USERS_WITH_FILTER
-import com.example.nav3recipes.deeplink.common.EntryScreen
-import com.example.nav3recipes.deeplink.common.FriendsList
-import com.example.nav3recipes.deeplink.common.LIST_USERS
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.FriendsList
+import com.example.nav3recipes.common.deeplink.LIST_USERS
 
 /**
  * Parses a target deeplink into a NavKey. There are several crucial steps involved:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -2,16 +2,14 @@ plugins {
     id("com.android.library")
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
-    namespace = "com.example.nav3recipes"
+    namespace = "com.example.nav3recipes.common"
     compileSdk = 36
 
     defaultConfig {
         minSdk = 24
-        targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -31,9 +29,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-    kotlinOptions {
-        jvmTarget = "11"
     }
 }
 

--- a/common/src/main/kotlin/com/example/nav3recipes/common/deeplink/Screens.kt
+++ b/common/src/main/kotlin/com/example/nav3recipes/common/deeplink/Screens.kt
@@ -1,4 +1,4 @@
-package com.example.nav3recipes.deeplink.common
+package com.example.nav3recipes.common.deeplink
 
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable

--- a/common/src/main/kotlin/com/example/nav3recipes/common/deeplink/User.kt
+++ b/common/src/main/kotlin/com/example/nav3recipes/common/deeplink/User.kt
@@ -1,4 +1,4 @@
-package com.example.nav3recipes.deeplink.common
+package com.example.nav3recipes.common.deeplink
 
 import kotlinx.serialization.Serializable
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,26 +13,26 @@
 # limitations under the License.
 
 [versions]
-agp = "8.13.1"
-kotlin = "2.2.21"
-coreKtx = "1.17.0"
+agp = "9.1.0"
+kotlin = "2.3.20"
+coreKtx = "1.18.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-kotlinxSerializationCore = "1.9.0"
+kotlinxSerializationCore = "1.10.0"
 lifecycleRuntimeKtx = "2.10.0"
 lifecycleViewmodel = "2.10.0"
-activityCompose = "1.12.0"
-composeBom = "2025.11.00"
+activityCompose = "1.13.0"
+composeBom = "2026.03.00"
 fragment =  "1.8.9"
-navigation2 = "2.9.6"
+navigation2 = "2.9.7"
 navigation3 = "1.1.0-beta01"
 material3 = "1.4.0"
-nav3Material = "1.3.0-alpha03"
-ksp = "2.3.2"
-hilt = "2.57.2"
+nav3Material = "1.3.0-alpha09"
+ksp = "2.3.6"
+hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
-koin = "4.2.0-beta2"
+koin = "4.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -68,7 +68,6 @@ koin-navigation3 = {group = "io.insert-koin", name = "koin-compose-navigation3",
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 01 15:05:21 BST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
AGP 9 requires modules to have unique package names by default, hence the change from `com.example.nav3recipes` to `com.example.nav3recipes.common` for the `common` module (and, by extension from `com.example.nav3recipes.deeplink.common` to `com.example.nav3recipes.common.deeplink`).