### PR TITLE
Remove hardcoded height on Heading ListItem (#227)

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -175,7 +174,6 @@ class RecipePickerActivity : ComponentActivity() {
                                     fontWeight = FontWeight.Bold
                                 )
                             },
-                            modifier = Modifier.height(48.dp),
                             colors = ListItemDefaults.colors(
                                 containerColor = MaterialTheme.colorScheme.surfaceVariant
                             )


### PR DESCRIPTION
Fixes #227

Removes `Modifier.height(48.dp)` from the Heading `ListItem` so long titles don't get clipped on narrower screens. Every other `ListItem` in the project already lets Material3 handle sizing.

**Before / After**

| Before | After |
|--------|-------|
| ![IMG_20260323_091301_360](https://github.com/user-attachments/assets/3a48e042-2d42-4a9a-9ad0-9c2260e68579) | ![IMG_20260323_091304_290](https://github.com/user-attachments/assets/de5b8377-b9b3-40ac-9e9f-6f1c6eb63cc9) |