### PR TITLE
Fix: Provide proper LocalLifecycleOwner to BottomSheetScene content

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/bottomsheet/BottomSheetSceneStrategy.kt
+++ b/app/src/main/java/com/example/nav3recipes/bottomsheet/BottomSheetSceneStrategy.kt
@@ -4,6 +4,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.rememberLifecycleOwner
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavMetadataKey
 import androidx.navigation3.runtime.get
@@ -28,11 +31,14 @@ internal data class BottomSheetScene<T : Any>(
     override val entries: List<NavEntry<T>> = listOf(entry)
 
     override val content: @Composable (() -> Unit) = {
+        val lifecycleOwner = rememberLifecycleOwner()
         ModalBottomSheet(
             onDismissRequest = onBack,
             properties = modalBottomSheetProperties,
         ) {
-            entry.Content()
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                entry.Content()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Provides a correct `LocalLifecycleOwner` to content within `BottomSheetScene`.

## Changes

Wraps `entry.Content()` with `CompositionLocalProvider`.

## Context

Follows the same pattern as [`DialogScene` in `navigation3`](https://github.com/androidx/androidx/blob/21617972a76faf6a3302cca1d27ce7501a118f31/navigation3/navigation3-ui/src/commonMain/kotlin/androidx/navigation3/scene/DialogScene.kt#L43-L48). Since `ModalBottomSheet` operates in a separate window, the `LifecycleOwner` is not automatically inherited. Providing it manually ensures correct lifecycle handling for the content.

## Verification

Lifecycle events (such as `onPause` and `onStop`) are triggered in the correct order.