### PR TITLE
Simplify Metro recipe implementation

### DIFF
--- a/metroapp/src/main/java/com/example/nav3recipes/Nav3MetroApplication.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/Nav3MetroApplication.kt
@@ -7,5 +7,5 @@ import dev.zacsweers.metrox.android.MetroAppComponentProviders
 import dev.zacsweers.metrox.android.MetroApplication
 
 class Nav3MetroApplication : Application(), MetroApplication {
-    override val appComponentProviders: MetroAppComponentProviders by lazy { createGraphFactory<MetroGraph.Factory>().create(this) }
+    override val appComponentProviders: MetroAppComponentProviders by lazy { createGraphFactory<MetroGraph.Factory>().create() }
 }

--- a/metroapp/src/main/java/com/example/nav3recipes/modular/metro/AppModule.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/modular/metro/AppModule.kt
@@ -1,11 +1,13 @@
 package com.example.nav3recipes.modular.metro
 
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 @ContributesTo(ActivityScope::class)
-interface AppModule {
+@BindingContainer
+object AppModule {
 
     @Provides
     @SingleIn(ActivityScope::class)

--- a/metroapp/src/main/java/com/example/nav3recipes/modular/metro/ConversationModule.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/modular/metro/ConversationModule.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.dropUnlessResumed
 import com.example.nav3recipes.ui.theme.colors
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
@@ -38,7 +39,8 @@ data class ConversationDetail(val id: Int) {
 
 // IMPL
 @ContributesTo(ActivityScope::class)
-interface ConversationModule {
+@BindingContainer
+object ConversationModule {
 
     @IntoSet
     @Provides

--- a/metroapp/src/main/java/com/example/nav3recipes/modular/metro/MetroGraph.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/modular/metro/MetroGraph.kt
@@ -11,7 +11,7 @@ import dev.zacsweers.metrox.viewmodel.ViewModelGraph
 
     @DependencyGraph.Factory
     interface Factory {
-        fun create(@Provides context: Context): MetroGraph
+        fun create(): MetroGraph
     }
 }
 

--- a/metroapp/src/main/java/com/example/nav3recipes/modular/metro/MetroModularActivity.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/modular/metro/MetroModularActivity.kt
@@ -18,13 +18,10 @@ import dev.zacsweers.metrox.android.ActivityKey
 @ContributesIntoMap(ActivityScope::class, binding<Activity>())
 @ActivityKey
 @Inject
-class MetroModularActivity : ComponentActivity() {
-
-    @Inject
-    lateinit var navigator: Navigator
-
-    @Inject
-    lateinit var entryProviderScopes: Set<@JvmSuppressWildcards EntryProviderInstaller>
+class MetroModularActivity(
+    private val navigator: Navigator,
+    private val entryProviderScopes: Set<@JvmSuppressWildcards EntryProviderInstaller>
+) : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/metroapp/src/main/java/com/example/nav3recipes/modular/metro/ProfileModule.kt
+++ b/metroapp/src/main/java/com/example/nav3recipes/modular/metro/ProfileModule.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.IntoSet
 import dev.zacsweers.metro.Provides
@@ -20,7 +21,8 @@ object Profile
 
 // IMPLEMENTATION
 @ContributesTo(ActivityScope::class)
-interface ProfileModule {
+@BindingContainer
+object ProfileModule {
 
     @IntoSet
     @Provides


### PR DESCRIPTION
* Refactored Metro module interfaces (`AppModule`, `ConversationModule`, and `ProfileModule`) to `object` declarations and [annotated them with `@BindingContainer`](https://zacsweers.github.io/metro/1.1.1/dependency-graphs/#binding-containers).
* Migrated `MetroModularActivity`, `InjectedViewModelFactory`, and `MetroViewModelsActivity` to constructor injection using class-level `@Inject` annotations (primary constructor injection).
* Removed the unused `@Provides context: Context` dependency from `MetroGraph.kt` and updated its instantiation in `Nav3MetroApplication`.