### PR TITLE
feat: add overlay scene recipe with shared element transition support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Read the [guide to deeplinking](docs/deeplink-guide.md). Upvote [this issue](htt
 - **[BottomSheet](app/src/main/java/com/example/nav3recipes/bottomsheet)**: Shows how to create a BottomSheet destination.
 - **[List-Detail Scene](app/src/main/java/com/example/nav3recipes/scenes/listdetail)**: Shows how to create a custom, list-detail layout using a `Scene` and `SceneStrategy` (see video of UI behavior below).
 - **[Two pane Scene](app/src/main/java/com/example/nav3recipes/scenes/twopane)**: Shows how to create a custom, 2-pane layout.
+- **[Overlay](app/src/main/java/com/example/nav3recipes/overlay)**: Shows how to create a custom overlay scene that displays one screen on top of another, enabling shared element transitions.
 
 #### Use Material Scenes
 Examples showing how to use the layouts provided by the [Compose Material3 Adaptive Navigation3 library](https://developer.android.com/jetpack/androidx/releases/compose-material3-adaptive#compose_material3_adaptive_navigation3_version_10_2)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -217,6 +217,10 @@
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
+            android:name=".overlay.OverlayActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Nav3Recipes"/>
+        <activity
             android:name=".dynamicfeature.DynamicFeatureActivity"
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>

--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -59,6 +59,7 @@ import com.example.nav3recipes.material.listdetail.MaterialListDetailActivity
 import com.example.nav3recipes.material.supportingpane.MaterialSupportingPaneActivity
 import com.example.nav3recipes.modular.hilt.HiltModularActivity
 import com.example.nav3recipes.modular.koin.KoinModularActivity
+import com.example.nav3recipes.overlay.OverlayActivity
 import com.example.nav3recipes.multiplestacks.MultipleStacksActivity
 import com.example.nav3recipes.navscenedecorator.ResponsiveNavigationSceneDecoratorActivity
 import com.example.nav3recipes.passingarguments.viewmodels.basic.BasicViewModelsActivity
@@ -95,6 +96,7 @@ private val recipes = listOf(
     Recipe("Two pane", TwoPaneActivity::class.java),
     Recipe("Bottom Sheet", BottomSheetActivity::class.java),
     Recipe("Dialog", DialogActivity::class.java),
+    Recipe("Overlay", OverlayActivity::class.java),
 
     Heading("Scene decorators"),
     Recipe("Responsive Navigation UI", ResponsiveNavigationSceneDecoratorActivity::class.java),

--- a/app/src/main/java/com/example/nav3recipes/overlay/OverlayActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/overlay/OverlayActivity.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.overlay
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.overlay.OverlaySceneStrategy.Companion.overlay
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data object HomeRoute : NavKey
+
+@Serializable
+private data class CommentRoute(val commentId: String, val author: String, val rating: Int) : NavKey
+
+class OverlayActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+        setContent {
+            val backStack = rememberNavBackStack(HomeRoute)
+            val overlayStrategy = remember { OverlaySceneStrategy<NavKey>() }
+
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                sceneStrategies = listOf(overlayStrategy),
+                entryProvider = entryProvider {
+                    entry<HomeRoute> {
+                        HomeScreen {
+                            backStack.add(
+                                CommentRoute(
+                                    commentId = "1",
+                                    author = "Jane Doe",
+                                    rating = 5
+                                )
+                            )
+                        }
+                    }
+                    entry<CommentRoute>(
+                        metadata = overlay(overlayHeightFraction = 0.65f)
+                    ) { key ->
+                        CommentOverlayScreen(key)
+                    }
+                }
+            )
+        }
+    }
+}
+
+// --- Home Screen ---
+
+@Composable
+private fun HomeScreen(onShowComment: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Overlay Scene Recipe",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Text(
+            text = "Tap the card below to see an overlay with shared element transition support.",
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(bottom = 24.dp)
+        )
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp),
+            shape = RoundedCornerShape(16.dp),
+            onClick = onShowComment,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = "📝",
+                    modifier = Modifier.size(48.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "View Comment Details",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = "Tap to open overlay",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}
+
+// --- Comment Overlay Screen ---
+
+@Composable
+private fun CommentOverlayScreen(comment: CommentRoute) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxSize()
+            .shadow(8.dp, RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+            .background(Color.White),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding()
+                .padding(16.dp)
+        ) {
+            // Drag handle
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(bottom = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Spacer(
+                    modifier = Modifier
+                        .height(4.dp)
+                        .fillMaxWidth(0.12f)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(Color.Gray.copy(alpha = 0.3f))
+                )
+            }
+
+            // Header with back button
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(
+                    onClick = { /* Handled by BackHandler in OverlayScene */ }
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+                Text(
+                    text = "Comment Details",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.size(48.dp)) // Balance the back button
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Author info
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(Color.Blue.copy(alpha = 0.2f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = comment.author.first().toString(),
+                        fontWeight = FontWeight.Bold,
+                        color = Color.Blue
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Column {
+                    Text(
+                        text = comment.author,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = "Comment #${comment.commentId}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Rating
+            Text(
+                text = "Rating",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Row(
+                modifier = Modifier.padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                repeat(5) { index ->
+                    Text(
+                        text = "⭐",
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+                Text(
+                    text = "${comment.rating}/5",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Expandable content
+            Button(
+                onClick = { isExpanded = !isExpanded },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (isExpanded) "Show Less" else "Show Full Comment")
+            }
+
+            AnimatedVisibility(
+                visible = isExpanded,
+                enter = fadeIn(animationSpec = tween(200)) + scaleIn(animationSpec = tween(200)),
+                exit = fadeOut(animationSpec = tween(200))
+            ) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text(
+                        text = "This is a sample comment content. In a real app, this would contain the full comment text, along with actions like reply, edit, or delete. The overlay pattern allows shared element transitions between the home screen card and this detailed view.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(
+                    onClick = { /* Reply action */ },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Reply")
+                }
+                Button(
+                    onClick = { /* Edit action */ },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Edit")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/nav3recipes/overlay/OverlaySceneStrategy.kt
+++ b/app/src/main/java/com/example/nav3recipes/overlay/OverlaySceneStrategy.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.nav3recipes.overlay
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavMetadataKey
+import androidx.navigation3.runtime.metadata
+import androidx.navigation3.scene.OverlayScene
+import androidx.navigation3.scene.Scene
+import androidx.navigation3.scene.SceneStrategy
+import androidx.navigation3.scene.SceneStrategyScope
+
+/**
+ * An [OverlayScene] that renders an [overlayEntry] on top of an [overlaidEntry] within a [Box].
+ *
+ * This scene enables shared element transitions between the overlaid and overlaying entries,
+ * which is not currently supported by Nav3's screen-to-window transitions.
+ *
+ * @property key The scene key.
+ * @property previousEntries The entries that were on the back stack before this scene.
+ * @property overlaidEntry The [NavEntry] displayed underneath.
+ * @property overlayEntry The [NavEntry] displayed on top.
+ * @property overlayHeightFraction The fraction of the screen height the overlay occupies (0.0–1.0).
+ * @property onBack The callback invoked when the user dismisses the overlay.
+ */
+data class OverlayScene<T : Any>(
+    override val key: Any,
+    override val previousEntries: List<NavEntry<T>>,
+    val overlaidEntry: NavEntry<T>,
+    val overlayEntry: NavEntry<T>,
+    val overlayHeightFraction: Float = 0.75f,
+    private val onBack: () -> Unit,
+) : OverlayScene<T> {
+
+    override val entries: List<NavEntry<T>> = listOf(overlaidEntry, overlayEntry)
+
+    override val content: @Composable (() -> Unit) = {
+        Box(Modifier.fillMaxSize()) {
+            // The underlying content
+            overlaidEntry.Content()
+
+            // The overlay content, positioned at the bottom
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .height((overlayHeightFraction * 100).dp),
+                contentAlignment = Alignment.Center
+            ) {
+                overlayEntry.Content()
+            }
+        }
+
+        // Back handler to dismiss the overlay
+        BackHandler {
+            onBack()
+        }
+    }
+}
+
+/**
+ * A [SceneStrategy] that creates an [OverlayScene] when the last entry in the back stack
+ * has been marked with [overlay].
+ *
+ * The strategy takes the second-to-last entry as the overlaid content and the last entry
+ * (with the overlay metadata) as the overlay content.
+ *
+ * This strategy should be added before any non-overlay scene strategies.
+ *
+ * @property overlayHeightFraction The fraction of the screen height the overlay occupies.
+ */
+class OverlaySceneStrategy<T : Any>(
+    private val overlayHeightFraction: Float = 0.75f,
+) : SceneStrategy<T> {
+
+    override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
+        if (entries.size < 2) return null
+
+        val lastEntry = entries.lastOrNull() ?: return null
+        val overlayConfig = lastEntry.metadata[OverlayKey] ?: return null
+
+        val overlaidEntry = entries[entries.size - 2]
+
+        return OverlayScene(
+            key = lastEntry.contentKey,
+            previousEntries = entries.dropLast(1),
+            overlaidEntry = overlaidEntry,
+            overlayEntry = lastEntry,
+            overlayHeightFraction = overlayConfig.overlayHeightFraction ?: overlayHeightFraction,
+            onBack = onBack,
+        )
+    }
+
+    companion object {
+        /**
+         * Function to be called on the [NavEntry.metadata] to mark this entry as something that
+         * should be displayed as an overlay on top of the previous entry.
+         *
+         * @param overlayHeightFraction Optional fraction of screen height (0.0–1.0) for the overlay.
+         *   Defaults to 0.75 if not specified.
+         */
+        fun overlay(overlayHeightFraction: Float? = null) = metadata {
+            put(OverlayKey, OverlayConfig(overlayHeightFraction))
+        }
+
+        /**
+         * Metadata key for overlay configuration.
+         */
+        object OverlayKey : NavMetadataKey<OverlayConfig>
+    }
+}
+
+/**
+ * Configuration for an overlay entry.
+ *
+ * @property overlayHeightFraction The fraction of screen height the overlay occupies.
+ */
+data class OverlayConfig(
+    val overlayHeightFraction: Float? = null,
+)


### PR DESCRIPTION
## What

Add a custom `OverlayScene` and `OverlaySceneStrategy` that enables displaying one NavEntry on top of another within a `Box` layout. This pattern supports shared element transitions between the overlaid and overlaying entries, addressing the limitation that Nav3 screen-to-window transitions don't support shared element animations.

Addresses: https://github.com/android/nav3-recipes/issues/213

## Changes

- **OverlaySceneStrategy.kt** — New file containing:
  - `OverlayScene<T>` — An `OverlayScene` that renders an overlay entry on top of an overlaid entry within a `Box`
  - `OverlaySceneStrategy<T>` — A `SceneStrategy` that activates when an entry has the `overlay()` metadata
  - `OverlayConfig` — Configuration class with configurable `overlayHeightFraction` (0.0–1.0)
  - `BackHandler` integrated to dismiss the overlay on back press

- **OverlayActivity.kt** — Demo activity with a home screen card that opens a comment detail overlay with:
  - Drag handle
  - Author info with avatar
  - Star rating display
  - Expandable comment content
  - Action buttons (Reply, Edit)

- **README.md** — Added documentation link under "Create custom Scenes"

- **AndroidManifest.xml** — Added `OverlayActivity` declaration

- **RecipePickerActivity.kt** — Added import and recipe entry for the new overlay recipe

## Design Decisions

- Follows the existing `BottomSheetScene` pattern (implements `OverlayScene<T>`)
- Uses `metadata { put(OverlayKey, OverlayConfig(...)) }` for marking overlay entries — consistent with existing recipes
- Configurable overlay height fraction (default 0.75)
- `BackHandler` inside the scene's `content` composable for proper back dismissal
- Both entries coexist in the same scene, enabling shared element transitions that Nav3's screen-to-window transitions don't currently support