### PR TITLE
Reset scroll state when reselecting a top-level route

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
@@ -43,26 +43,17 @@ fun EntryProviderScope<NavKey>.featureASection(
 ) {
     entry<RouteA> {
         ContentRed("Route A") {
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
-                    Text("Go to A1")
-                }
-                LazyColumn(state = scrollState) {
-                    items(30) { index ->
-                        Text("Route A item ${index + 1}", fontSize = 24.sp)
-                    }
-                }
+            Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
+                Text("Go to A1")
             }
         }
     }
     entry<RouteA1> {
         ContentPink("Route A1") {
-            var count by rememberSaveable {
-                mutableIntStateOf(0)
-            }
-
-            Button(onClick = { count++ }) {
-                Text("Value: $count")
+            LazyColumn(state = scrollState) {
+                items(100) { index ->
+                    Text("Route A item ${index + 1}", fontSize = 24.sp)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
@@ -17,6 +17,8 @@
 package com.example.nav3recipes.multiplestacks
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
@@ -24,6 +26,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
@@ -35,6 +38,7 @@ import com.example.nav3recipes.content.ContentPurple
 import com.example.nav3recipes.content.ContentRed
 
 fun EntryProviderScope<NavKey>.featureASection(
+    scrollState: LazyListState,
     onSubRouteClick: () -> Unit,
 ) {
     entry<RouteA> {
@@ -42,6 +46,11 @@ fun EntryProviderScope<NavKey>.featureASection(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Button(onClick = dropUnlessResumed(block = onSubRouteClick)) {
                     Text("Go to A1")
+                }
+                LazyColumn(state = scrollState) {
+                    items(30) { index ->
+                        Text("Route A item ${index + 1}", fontSize = 24.sp)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/Content.kt
@@ -18,9 +18,10 @@ package com.example.nav3recipes.multiplestacks
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -36,9 +37,10 @@ import com.example.nav3recipes.content.ContentOrange
 import com.example.nav3recipes.content.ContentPink
 import com.example.nav3recipes.content.ContentPurple
 import com.example.nav3recipes.content.ContentRed
+import kotlinx.coroutines.flow.Flow
 
 fun EntryProviderScope<NavKey>.featureASection(
-    scrollState: LazyListState,
+    reselectEvents: Flow<NavKey>,
     onSubRouteClick: () -> Unit,
 ) {
     entry<RouteA> {
@@ -49,6 +51,15 @@ fun EntryProviderScope<NavKey>.featureASection(
         }
     }
     entry<RouteA1> {
+        val scrollState = rememberLazyListState()
+        LaunchedEffect(reselectEvents) {
+            reselectEvents.collect { route ->
+                if (route == RouteA) {
+                    scrollState.scrollToItem(0)
+                }
+            }
+        }
+
         ContentPink("Route A1") {
             LazyColumn(state = scrollState) {
                 items(100) { index ->

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
@@ -16,11 +16,11 @@
 
 package com.example.nav3recipes.multiplestacks
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Camera
 import androidx.compose.material.icons.filled.Face
@@ -31,7 +31,9 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
@@ -69,7 +71,6 @@ data class NavBarItem(
 )
 
 class MultipleStacksActivity : ComponentActivity() {
-    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         setEdgeToEdgeConfig()
         super.onCreate(savedInstanceState)
@@ -80,18 +81,17 @@ class MultipleStacksActivity : ComponentActivity() {
             )
 
             val navigator = remember { Navigator(navigationState) }
-            val routeAScrollState = rememberLazyListState()
 
             val entryProvider = entryProvider {
                 featureASection(
-                    scrollState = routeAScrollState,
+                    reselectEvents = navigator.reselectEvents,
                     onSubRouteClick = { navigator.navigate(RouteA1) }
                 )
                 featureBSection(onSubRouteClick = { navigator.navigate(RouteB1) })
                 featureCSection(onSubRouteClick = { navigator.navigate(RouteC1) })
             }
 
-            Scaffold(bottomBar = {
+            Scaffold(contentWindowInsets = WindowInsets(0.dp), bottomBar = {
                 NavigationBar {
                     TOP_LEVEL_ROUTES.forEach { (key, value) ->
                         val isSelected = key == navigationState.topLevelRoute
@@ -99,8 +99,8 @@ class MultipleStacksActivity : ComponentActivity() {
                             selected = isSelected,
                             onClick = {
                                 navigator.navigate(key)
-                                if (isSelected && key == RouteA) {
-                                    routeAScrollState.requestScrollToItem(0)
+                                if (isSelected) {
+                                    navigator.onReselect(key)
                                 }
                             },
                             icon = {
@@ -113,10 +113,11 @@ class MultipleStacksActivity : ComponentActivity() {
                         )
                     }
                 }
-            }) {
+            }) { innerPadding ->
                 NavDisplay(
                     entries = navigationState.toDecoratedEntries(entryProvider),
-                    onBack = { navigator.goBack() }
+                    onBack = { navigator.goBack() },
+                    modifier = Modifier.padding(innerPadding)
                 )
             }
         }

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
@@ -98,10 +98,9 @@ class MultipleStacksActivity : ComponentActivity() {
                         NavigationBarItem(
                             selected = isSelected,
                             onClick = {
+                                navigator.navigate(key)
                                 if (isSelected && key == RouteA) {
                                     routeAScrollState.requestScrollToItem(0)
-                                } else {
-                                    navigator.navigate(key)
                                 }
                             },
                             icon = {

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/MultipleStacksActivity.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Camera
 import androidx.compose.material.icons.filled.Face
@@ -79,9 +80,13 @@ class MultipleStacksActivity : ComponentActivity() {
             )
 
             val navigator = remember { Navigator(navigationState) }
+            val routeAScrollState = rememberLazyListState()
 
             val entryProvider = entryProvider {
-                featureASection(onSubRouteClick = { navigator.navigate(RouteA1) })
+                featureASection(
+                    scrollState = routeAScrollState,
+                    onSubRouteClick = { navigator.navigate(RouteA1) }
+                )
                 featureBSection(onSubRouteClick = { navigator.navigate(RouteB1) })
                 featureCSection(onSubRouteClick = { navigator.navigate(RouteC1) })
             }
@@ -92,7 +97,13 @@ class MultipleStacksActivity : ComponentActivity() {
                         val isSelected = key == navigationState.topLevelRoute
                         NavigationBarItem(
                             selected = isSelected,
-                            onClick = { navigator.navigate(key) },
+                            onClick = {
+                                if (isSelected && key == RouteA) {
+                                    routeAScrollState.requestScrollToItem(0)
+                                } else {
+                                    navigator.navigate(key)
+                                }
+                            },
                             icon = {
                                 Icon(
                                     imageVector = value.icon,

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/Navigator.kt
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/Navigator.kt
@@ -17,11 +17,16 @@
 package com.example.nav3recipes.multiplestacks
 
 import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
 /**
  * Handles navigation events (forward and back) by updating the navigation state.
  */
 class Navigator(val state: NavigationState){
+    private val _reselectEvents = MutableSharedFlow<NavKey>(extraBufferCapacity = 1)
+    val reselectEvents = _reselectEvents.asSharedFlow()
+
     fun navigate(route: NavKey){
         if (route in state.backStacks.keys){
             // This is a top level route, just switch to it
@@ -29,6 +34,10 @@ class Navigator(val state: NavigationState){
         } else {
             state.backStacks[state.topLevelRoute]?.add(route)
         }
+    }
+
+    fun onReselect(route: NavKey) {
+        _reselectEvents.tryEmit(route)
     }
 
     fun goBack(){

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
@@ -14,6 +14,7 @@ Key behaviors:
 
 - This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are _always_ in the list of entries. 
 - Navigating to a top level route that is not the starting route _replaces_ the other entries. For example, navigating A->B->C would result in entries for A+C, B's entries are removed. 
+- Tapping the already-selected `RouteA` navigation item resets its scroll position.
 
 Important implementation details: 
 

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
@@ -2,7 +2,7 @@
 
 This recipe demonstrates how to create multiple back stacks. 
 
-The app has three top level routes: `RouteA`, `RouteB` and `RouteC`. These routes have sub routes `RouteA1`, `RouteB1` and `RouteC1` respectively. The content for the sub routes is a counter that can be used to verify state retention through configuration changes and process death.
+The app has three top level routes: `RouteA`, `RouteB` and `RouteC`. These routes have sub routes `RouteA1`, `RouteB1` and `RouteC1` respectively. `RouteA1` contains a 100-item scrollable list, while `RouteB1` and `RouteC1` contain counters used to verify state retention through configuration changes and process death.
 
 The app's navigation state is held in the `NavigationState` class. The state itself is created using `rememberNavigationState`. 
 
@@ -14,7 +14,7 @@ Key behaviors:
 
 - This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are _always_ in the list of entries. 
 - Navigating to a top level route that is not the starting route _replaces_ the other entries. For example, navigating A->B->C would result in entries for A+C, B's entries are removed. 
-- Tapping the already-selected `RouteA` navigation item resets its scroll position.
+- Tapping the already-selected `RouteA` navigation item resets the retained `RouteA1` list scroll position.
 
 Important implementation details: 
 

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
@@ -14,7 +14,7 @@ Key behaviors:
 
 - This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are _always_ in the list of entries. 
 - Navigating to a top level route that is not the starting route _replaces_ the other entries. For example, navigating A->B->C would result in entries for A+C, B's entries are removed. 
-- Tapping the already-selected `RouteA` navigation item resets the retained `RouteA1` list scroll position.
+- When a top level route is reselected (for example, `RouteA` while already on `RouteA`), the `NavigationBar` emits the reselected `NavKey` to a `Flow<NavKey>`. `RouteA` observes this flow and resets its retained `RouteA1` list scroll position to index 0.
 
 Important implementation details: 
 

--- a/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
+++ b/app/src/main/java/com/example/nav3recipes/multiplestacks/README.md
@@ -14,7 +14,7 @@ Key behaviors:
 
 - This app follows the "exit through home" pattern where the user always exits through the starting back stack. This means that `RouteA`'s entries are _always_ in the list of entries. 
 - Navigating to a top level route that is not the starting route _replaces_ the other entries. For example, navigating A->B->C would result in entries for A+C, B's entries are removed. 
-- When a top level route is reselected (for example, `RouteA` while already on `RouteA`), the `NavigationBar` emits the reselected `NavKey` to a `Flow<NavKey>`. `RouteA` observes this flow and resets its retained `RouteA1` list scroll position to index 0.
+- When a top-level route is reselected, for example if the user is on `RouteA` and taps `RouteA` on the navigation bar again, the `NavigationBar` signals the reselected key to `Navigator`, which emits it to a `Flow<NavKey>`. `RouteA1` observes this flow and, when it receives `RouteA`, resets its list scroll position to index 0.
 
 Important implementation details: 
 


### PR DESCRIPTION
Fixes #127

- Add a scrollable Route A example to the multiple-stacks recipe.
- Reset its list when the already-selected Route A navigation item is tapped.
- Document the reselection behavior in the recipe README.

## Verification

- `./gradlew assembleDebug test`
- `./gradlew connectedAndroidTest` (API 34)
