### PR TITLE
Add recipe for deep linking with static uri

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -147,6 +147,16 @@
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes"/>
         <activity
+            android:name=".deeplink.staticuri.StaticUriDeepLinkActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Nav3Recipes">
+        </activity>
+        <activity
+            android:name=".deeplink.staticuri.MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Nav3Recipes">
+        </activity>
+        <activity
             android:name=".deeplink.basic.CreateDeepLinkActivity"
             android:exported="true"
             android:theme="@style/Theme.Nav3Recipes">

--- a/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/RecipePickerActivity.kt
@@ -51,6 +51,7 @@ import com.example.nav3recipes.commonui.CommonUiActivity
 import com.example.nav3recipes.conditional.ConditionalActivity
 import com.example.nav3recipes.deeplink.advanced.AdvancedCreateDeepLinkActivity
 import com.example.nav3recipes.deeplink.basic.CreateDeepLinkActivity
+import com.example.nav3recipes.deeplink.staticuri.StaticUriDeepLinkActivity
 import com.example.nav3recipes.dialog.DialogActivity
 import com.example.nav3recipes.dialogscenedecorator.DialogSceneDecoratorActivity
 import com.example.nav3recipes.dynamicfeature.DynamicFeatureActivity
@@ -130,6 +131,7 @@ private val recipes = listOf(
     Recipe("Return result as Serializable State", ResultSerializableActivity::class.java),
 
     Heading("Deeplink"),
+    Recipe("Static Uri", StaticUriDeepLinkActivity::class.java),
     Recipe("Parse Intent", CreateDeepLinkActivity::class.java),
     Recipe("Synthetic BackStack", AdvancedCreateDeepLinkActivity::class.java),
 

--- a/app/src/main/java/com/example/nav3recipes/deeplink/README.md
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/README.md
@@ -1,0 +1,10 @@
+# Deep Link Recipes
+
+This module contains the main recipes for deep linking with Navigation3.
+
+## Recipe structure
+
+The deep link module consists of three main packages:
+1. `staticuri` - Shows the simple use case of deep linking with a static uri
+2. `basic` - Shows how to deep link with arguments 
+3. `advanced` - Shows how to deep link from one Activity to another Activity

--- a/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/MainActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/MainActivity.kt
@@ -1,0 +1,79 @@
+package com.example.nav3recipes.deeplink.staticuri
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.ui.NavDisplay
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.TextContent
+import com.example.nav3recipes.deeplink.basic.HomeKey
+import com.example.nav3recipes.deeplink.basic.NavRecipeKey
+import androidx.navigation3.runtime.deeplink.DeepLinkRequest
+import androidx.navigation3.runtime.deeplink.DeepLinkUri
+import androidx.navigation3.runtime.deeplink.UriDeepLinkMatcher
+import androidx.navigation3.runtime.deeplink.invoke
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+
+
+@Serializable
+internal object FallbackKey: NavRecipeKey {
+    override val name: String = "Fallback Key"
+}
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        // create a DeepLinkRequest with the intent
+        val request = DeepLinkRequest(intent)
+
+        // try to match DeepLinkRequest to a DeepLinkMatcher
+        val matchResult = HOME_MATCHER.match(request)
+        val key = matchResult?.key ?: FallbackKey
+
+        /**
+         * Then pass starting key to backstack
+         */
+        setContent {
+            val backStack: NavBackStack<NavKey> = rememberNavBackStack(key)
+            NavDisplay(
+                backStack = backStack,
+                onBack = { backStack.removeLastOrNull() },
+                entryProvider = entryProvider {
+                    entry<HomeKey> { key ->
+                        EntryScreen(key.name) {
+                            TextContent("Deep linked to Home")
+                        }
+                    }
+                    entry<FallbackKey> { key ->
+                        EntryScreen("${key.name} ") {
+                            TextContent(
+                                "Failed to deep link - DeepLinkRequest " +
+                                    "did not match with any DeepLinkMatcher"
+                            )
+                        }
+                    }
+
+                }
+            )
+        }
+    }
+}
+
+/**
+ * Each matcher is associated with a navigation key that supports this deep link.
+ *
+ * A navigation key can be associated with multiple DeepLinkMatchers if it supports more than one deep link.
+ */
+private val HOME_MATCHER = UriDeepLinkMatcher(
+    uriPattern = DeepLinkUri(HOME_URI),
+    serializer = serializer<HomeKey>(),
+)

--- a/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/README.md
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/README.md
@@ -1,0 +1,15 @@
+# Deep Link Basic Recipe
+
+This recipe demonstrates how deep link with a static Uri.
+
+## Recipe components
+
+The recipe contains two activities:
+1. `StaticUriDeepLinkActivity` to construct and start an Intent with the deep link uri 
+2. `MainActivity` is the target Activity of the deep link, represents an app that users can deep link to.
+
+## How the demonstrated deep link works
+
+1. The deep link source (`StaticUriDeepLinkActivity`) defines the uri and creates an Intent to deep link with.
+2. The app (`MainActivity`) declares a navigation key (`HomeKey`). To indicate that `HomeKey` supports deep linking, the app declares a `UriDeepLinkMatcher` with the `HomeKey` serializer along with the uri pattern that `HomeKey` supports.
+3. `MainActivity` onCreate instantiates a `DeepLinkRequest` with the intent and matches it with the `UriDeepLinkMatcher` to get a `MatchResult`. If the `MatchResult` is non-null, the app navigates to the key returned by the result. Otherwise, the deep link is not supported and the app navigates to a `Fallback` screen.

--- a/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/StaticUriDeepLinkActivity.kt
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/staticuri/StaticUriDeepLinkActivity.kt
@@ -1,0 +1,37 @@
+package com.example.nav3recipes.deeplink.staticuri
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.net.toUri
+import androidx.lifecycle.compose.dropUnlessResumed
+import com.example.nav3recipes.common.deeplink.EntryScreen
+import com.example.nav3recipes.common.deeplink.PaddedButton
+import com.example.nav3recipes.common.deeplink.TextContent
+import com.example.nav3recipes.deeplink.basic.ui.PATH_BASE
+import com.example.nav3recipes.ui.setEdgeToEdgeConfig
+
+const val HOME_URI = "$PATH_BASE/home"
+
+class StaticUriDeepLinkActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        setEdgeToEdgeConfig()
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            EntryScreen("Deep link url:") {
+                TextContent(HOME_URI)
+                PaddedButton("Deeplink Away!", onClick = dropUnlessResumed {
+                    val intent = Intent(
+                        this@StaticUriDeepLinkActivity,
+                        MainActivity::class.java
+                    )
+                    // the uri to deep link with
+                    intent.data = HOME_URI.toUri()
+                    startActivity(intent)
+                })
+            }
+        }
+    }
+}


### PR DESCRIPTION
Show how to deep link with a static uri using UriDeepLinkMatcher.

Note: This is the first of many PRs to show deep linking with new APIs. To follow, existing deep link recipes will be refactored to new APIs including renaming packages (i.e. deeplink.basic will be renamed to something indicating it includes arguments).

Fixes #310