### PR TITLE
Fix flaky AtomicMigration dialog tests

### DIFF
--- a/app/src/androidTest/java/com/example/nav3recipes/AtomicMigrationTest.kt
+++ b/app/src/androidTest/java/com/example/nav3recipes/AtomicMigrationTest.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.IdlingPolicies
+import androidx.test.espresso.action.ViewActions.pressBack
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.example.nav3recipes.migration.atomic.begin.BeginAtomicMigrationActivity
 import com.example.nav3recipes.migration.atomic.end.EndAtomicMigrationActivity
 import org.junit.Before
@@ -133,16 +136,14 @@ class AtomicMigrationTest(activityClass: Class<out ComponentActivity>) {
         }
     }
 
-    /**
-     * TODO: Investigate why these dialog tests sometimes fail.
-     */
     @Test
     fun navigateToDialogD_onA_showsDialogContentAndDismisses() {
         composeTestRule.apply {
 
             onNodeWithText("Open dialog D").performClick()
             onNodeWithText("Route D title (dialog)").assertExists()
-            Espresso.pressBack()
+            Espresso.onView(isRoot()).inRoot(isDialog()).perform(pressBack())
+            onNodeWithText("Route D title (dialog)").assertDoesNotExist()
             onNodeWithText("Route A title").assertExists()
         }
     }
@@ -155,7 +156,8 @@ class AtomicMigrationTest(activityClass: Class<out ComponentActivity>) {
 
             onNodeWithText("Open dialog D").performClick()
             onNodeWithText("Route D title (dialog)").assertExists()
-            Espresso.pressBack()
+            Espresso.onView(isRoot()).inRoot(isDialog()).perform(pressBack())
+            onNodeWithText("Route D title (dialog)").assertDoesNotExist()
             onNodeWithText("Route B title").assertExists()
         }
     }
@@ -169,7 +171,8 @@ class AtomicMigrationTest(activityClass: Class<out ComponentActivity>) {
 
             onNodeWithText("Open dialog D").performClick()
             onNodeWithText("Route D title (dialog)").assertExists()
-            Espresso.pressBack()
+            Espresso.onView(isRoot()).inRoot(isDialog()).perform(pressBack())
+            onNodeWithText("Route D title (dialog)").assertDoesNotExist()
             onNodeWithText("Route C title").assertExists()
         }
     }


### PR DESCRIPTION
Closes #311

## Summary

- Target dialog Back actions at Espresso's dialog root so the underlying activity root is not selected while it lacks focus.
- Verify that dialog content is removed after dismissal and remove the resolved flake TODO.

## Testing

- `:app:compileDebugAndroidTestKotlin`
- `AtomicMigrationTest` (20/20 on Android API 34)
- All six dialog variants repeated 10 times (60/60)
- `assembleDebug test connectedAndroidTest` (21/21 app instrumentation tests on Android API 34)
