### PR TITLE
Refactor synthetic back stack recipe

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/syntheticbackstack/README.md
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/syntheticbackstack/README.md
@@ -12,7 +12,7 @@ contains the `SyntheticBackStackDeepLinkActivity` that allows you to create a de
 trigger that in either the existing Task, or in a new Task.
 
 "App B" is simulated by the module [syntheticbackstackapp](/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack), which contains
-the MainActivity that you deeplink into. That module shows you how to build a synthetic backStack
+the `SyntheticBackStackAppActivity` that you deeplink into. That module shows you how to build a synthetic backStack
 and how to manage the Task stack properly in order to support both Back and Up buttons.
 
 # How to Use
@@ -42,7 +42,7 @@ To see behavior of `New Task`:
 
 # Core implementation
 The core helper functions for navigateUp and building synthetic backStack can be
-found [here](/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/DeepLinkBackStackUtil.kt)
+found [here](/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util)
 
 # Further Read
 Check out the [deep link guide](/docs/deeplink-guide.md) for a 

--- a/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/README.md
+++ b/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/README.md
@@ -1,0 +1,19 @@
+# Deep Link Synthetic BackStack App
+
+The sample app that parses a deep link and builds a synthetic back stack based on the task stack state.
+
+# Recipe Structure
+
+The `util` package contains:
+
+1. `BackStackBuilder` - a `withBackStack` extension function that builds the synthetic back stack
+2. `SimpleDeepLinkMatcher` - a custom `DeepLinkMatcher` that parses the uri into a navigation key
+3. `BackStackUril` - contains the implementation of `Up` button and a helper to create a new task stack
+
+The main package contains:
+1. `NavRecipeKey` - The navigation keys
+2. `SyntheticBackStackAppActivity` - The app activity that parses the `Intent` and calls `withBackStack` to build an initial stack.
+
+# Further Read
+Check out the [deep link guide](/docs/deeplink-guide.md) for a
+comprehensive guide on Deep linking principles and how to apply them in Navigation 3.

--- a/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/SyntheticBackStackAppActivity.kt
+++ b/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/SyntheticBackStackAppActivity.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.deeplink.DeepLinkRequest
+import androidx.navigation3.runtime.deeplink.invoke
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
@@ -25,9 +27,9 @@ import com.example.nav3recipes.common.deeplink.EntryScreen
 import com.example.nav3recipes.common.deeplink.FriendsList
 import com.example.nav3recipes.common.deeplink.LIST_USERS
 import com.example.nav3recipes.common.deeplink.PaddedButton
-import com.example.nav3recipes.deeplink.syntheticbackstack.util.buildBackStack
+import com.example.nav3recipes.deeplink.syntheticbackstack.util.SimpleDeepLinkMatcher
 import com.example.nav3recipes.deeplink.syntheticbackstack.util.navigateUp
-import com.example.nav3recipes.deeplink.syntheticbackstack.util.toKey
+import com.example.nav3recipes.deeplink.syntheticbackstack.util.withBackStack
 
 class SyntheticBackStackAppActivity: ComponentActivity() {
 
@@ -36,18 +38,19 @@ class SyntheticBackStackAppActivity: ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        val startKey = intent.data.toKey()
+        val request = DeepLinkRequest(intent)
 
         val flags = intent.flags
         val isNewTask = flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0 &&
                 flags and Intent.FLAG_ACTIVITY_CLEAR_TASK != 0
 
-        val syntheticBackStack = buildBackStack(
-            startKey = startKey,
-            buildFullPath = isNewTask
-        )
+        val matcher = SimpleDeepLinkMatcher().withBackStack(isNewTask)
+        val backStack = matcher.match(request)?.backStack ?: listOf(Home)
+
         setContent {
-            val backStack: NavBackStack<NavKey> = rememberNavBackStack(*(syntheticBackStack.toTypedArray()))
+            val backStack: NavBackStack<NavKey> = rememberNavBackStack().apply {
+                addAll(backStack)
+            }
 
             Scaffold(
                 topBar = {

--- a/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/BackStackBuilder.kt
+++ b/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/BackStackBuilder.kt
@@ -1,0 +1,55 @@
+package com.example.nav3recipes.deeplink.syntheticbackstack.util
+
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.deeplink.BackStackMatcher
+import androidx.navigation3.runtime.deeplink.DeepLinkMatcher
+import androidx.navigation3.runtime.deeplink.withBackStack
+import com.example.nav3recipes.deeplink.syntheticbackstack.NavDeepLinkRecipeKey
+
+/**
+ * Maps a [SimpleDeepLinkMatcher] to a [BackStackMatcher]s.
+ *
+ * The returned [BackStackMatcher] builds a backStack with [DeepLinkMatcher.withBackStack].
+ *
+ * This sample implementation of [DeepLinkMatcher.withBackStack] can return one of two possible backStacks:
+ *
+ * 1. a backStack with only the deep linked key if [buildFullPath] is false.
+ * 2. a backStack containing the deep linked key and its hierarchical parent keys
+ * if [buildFullPath] is true.
+ *
+ * In the context of this recipe, [buildFullPath] is true if the deeplink intent has the
+ * [Intent.FLAG_ACTIVITY_NEW_TASK] and [Intent.FLAG_ACTIVITY_CLEAR_TASK]
+ * flags.
+ * These flags indicate that the deep linked Activity was started as the root Activity of a new Task, in which case
+ * a full synthetic backStack is required in order to support the proper, expected back button behavior.
+ *
+ * If those flags were not present, it means the deep linked Activity was started
+ * in the app that originally triggered the deeplink. In this case, that original app is assumed to
+ * already have existing screens that users can system back into, therefore a synthetic backstack
+ * is OPTIONAL.
+ *
+ * @param buildFullPath builds a full synthetic backStack if true. Otherwise, the back stack
+ * only contains the deep link target key.
+ */
+internal fun SimpleDeepLinkMatcher.withBackStack(
+    buildFullPath: Boolean
+): BackStackMatcher<NavKey, NavKey> = withBackStack { matchResult ->
+    val startKey = matchResult.key
+    if (!buildFullPath) {
+        listOf(matchResult.key)
+    } else {
+        /**
+         * iterate up the parents of the startKey until it reaches the root key (a key without a parent)
+         */
+        buildList {
+            var node: NavKey? = startKey
+            while (node != null) {
+                add(0, node)
+                val parent = if (node is NavDeepLinkRecipeKey) {
+                    node.parent
+                } else null
+                node = parent
+            }
+        }
+    }
+}

--- a/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/BackStackUtil.kt
+++ b/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/BackStackUtil.kt
@@ -3,61 +3,16 @@ package com.example.nav3recipes.deeplink.syntheticbackstack.util
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.core.app.TaskStackBuilder
 import androidx.core.net.toUri
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import com.example.nav3recipes.common.deeplink.LIST_USERS
-import com.example.nav3recipes.deeplink.syntheticbackstack.DEEPLINK_URL_TAG_USER
-import com.example.nav3recipes.deeplink.syntheticbackstack.DEEPLINK_URL_TAG_USERS
-import com.example.nav3recipes.deeplink.syntheticbackstack.Home
 import com.example.nav3recipes.deeplink.syntheticbackstack.NavDeepLinkRecipeKey
-import com.example.nav3recipes.deeplink.syntheticbackstack.UserDetail
-import com.example.nav3recipes.deeplink.syntheticbackstack.Users
 
 /**
- * A function that build a synthetic backStack.
+ * Navigates up in the back stack. This is triggered by
+ * the Up button (as opposed to a back button).
  *
- * This helper returns one of two possible backStacks:
- *
- * 1. a backStack with only the deeplinked key if [buildFullPath] is false.
- * 2. a backStack containing the deeplinked key and its hierarchical parent keys
- * if [buildFullPath] is true.
- *
- * In the context of this recipe, [buildFullPath] is true if the deeplink intent has the
- * [android.content.Intent.FLAG_ACTIVITY_NEW_TASK] and [android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK]
- * flags.
- * These flags indicate that the deeplinked Activity was started as the root Activity of a new Task, in which case
- * a full synthetic backStack is required in order to support the proper, expected back button behavior.
- *
- * If those flags were not present, it means the deeplinked Activity was started
- * in the app that originally triggered the deeplink. In this case, that original app is assumed to
- * already have existing screens that users can system back into, therefore a synthetic backstack
- * is OPTIONAL.
- *
- */
-internal fun buildBackStack(
-    startKey: NavKey,
-    buildFullPath: Boolean
-): List<NavKey> {
-    if (!buildFullPath) return listOf(startKey)
-    /**
-     * iterate up the parents of the startKey until it reaches the root key (a key without a parent)
-     */
-    return buildList {
-        var node: NavKey? = startKey
-        while (node != null) {
-            add(0, node)
-            val parent = if (node is NavDeepLinkRecipeKey) {
-                node.parent
-            } else null
-            node = parent
-        }
-    }
-}
-
-/**
  * If this app was started on its own Task stack, then navigate up would simply
  * pop from the backStack.
  *
@@ -76,9 +31,14 @@ internal fun NavBackStack<NavKey>.navigateUp(
     context: Context
 ) {
     /**
-     * The root key (the first key on synthetic backStack) would/should never display the Up button.
-     * So if the backStack only contains a non-root key, it means a synthetic backStack had not
-     * been built (aka the app was opened in the originating Task).
+     * The root key (the first key on a synthetic backStack) would/should never display the Up button.
+     *
+     * So if the backStack contains only one key, we can assume that the screen that this `up`
+     * button was triggered from was displaying a non-root key.
+     *
+     * Since the back stack only has a non-root key, it also means that a synthetic backStack had not
+     * been built (aka the app was opened in the originating Task). In this case, we would
+     * need to build one.
      */
     if (size == 1) {
         val currKey = last()
@@ -127,7 +87,7 @@ private fun createTaskStackBuilder(
      * can build the synthetic backStack starting from the deeplink key all the way up to the
      * root key.
      *
-     * See [buildBackStack] for building synthetic backStack.
+     * See [SimpleDeepLinkMatcher.withBackStack] for building synthetic backStack.
      */
     if (deeplinkKey != null && deeplinkKey is NavDeepLinkRecipeKey) {
         intent.data = deeplinkKey.deeplinkUrl.toUri()
@@ -145,31 +105,4 @@ private fun createTaskStackBuilder(
      * add the intents for the parent activities (if any) of [activity].
      */
     return TaskStackBuilder.create(context).addNextIntentWithParentStack(intent)
-}
-
-/**
- * A function that converts a deeplink uri into a NavKey.
- *
- * This helper is intentionally simple and basic. For a recipe that focuses on parsing a
- * deeplink uri into a NavKey, please see [com.example.nav3recipes.deeplink.basic].
- */
-internal fun Uri?.toKey(): NavKey {
-    if (this == null) return Home
-
-    val paths = pathSegments
-
-    if (pathSegments.isEmpty()) return Home
-
-    return when(paths.first()) {
-        DEEPLINK_URL_TAG_USERS -> Users
-        DEEPLINK_URL_TAG_USER -> {
-            val firstName = pathSegments[1]
-            val location = pathSegments[2]
-            val user = LIST_USERS.find {
-                it.firstName == firstName && it.location == location
-            }
-            if (user == null) Users else UserDetail(user)
-        }
-        else -> Home
-    }
 }

--- a/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/SimpleDeepLinkMatcher.kt
+++ b/syntheticbackstackapp/src/main/java/com/example/nav3recipes/deeplink/syntheticbackstack/util/SimpleDeepLinkMatcher.kt
@@ -1,0 +1,44 @@
+package com.example.nav3recipes.deeplink.syntheticbackstack.util
+
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.deeplink.DeepLinkMatcher
+import androidx.navigation3.runtime.deeplink.DeepLinkRequest
+import com.example.nav3recipes.common.deeplink.LIST_USERS
+import com.example.nav3recipes.deeplink.syntheticbackstack.DEEPLINK_URL_TAG_USER
+import com.example.nav3recipes.deeplink.syntheticbackstack.DEEPLINK_URL_TAG_USERS
+import com.example.nav3recipes.deeplink.syntheticbackstack.Home
+import com.example.nav3recipes.deeplink.syntheticbackstack.UserDetail
+import com.example.nav3recipes.deeplink.syntheticbackstack.Users
+
+/**
+ * An implementation of [DeepLinkMatcher] that determines the key based on the deep link Uri's first
+ * path segment.
+ */
+internal class SimpleDeepLinkMatcher: DeepLinkMatcher<NavKey, DeepLinkMatcher.MatchResult<NavKey>>() {
+    override fun matchRequest(request: DeepLinkRequest): MatchResult<NavKey> {
+        val paths = request.uri?.pathSegments
+
+        // default to Home
+        if (paths.isNullOrEmpty()) return MatchResult(Home)
+
+        return when(paths.first()) {
+            // "https://www.nav3deeplink.com/users"
+            DEEPLINK_URL_TAG_USERS -> MatchResult(Users)
+            // "https://www.nav3deeplink.com/user/$firstName/$location"
+            DEEPLINK_URL_TAG_USER -> {
+                val firstName = paths[1]
+                val location = paths[2]
+                val user = LIST_USERS.find {
+                    it.firstName == firstName && it.location == location
+                }
+                if (user == null) MatchResult(Users) else MatchResult(
+                    UserDetail(
+                        user
+                    )
+                )
+            }
+            // "https://www.nav3deeplink.com/home"
+            else -> MatchResult(Home) // default to Home
+        }
+    }
+}


### PR DESCRIPTION
Refactored to use the new deep link APIs. Contains the following changes:

1. A `SimpleDeepLinkMatcher` implementation of `DeepLinkMatcher` that matches uri based on first path segment
2. A `withBackStack` helper that takes a `buildFullBack` boolean input, delegates to the new `DeepLinkMatcher.withBackStack` API to build a back stack based on the input
3. Renamed `DeepLinkBackStackUtil.kt` to `BackStackUtil.kt` and removed helper functions that are now replaced by the new APIs
4. Refactored the Activity to use the new matcher and helpers
5. Added a README file

Fixes #301