### PR TITLE
Update deep link basic recipe titles to be more specific

### DIFF
--- a/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/staticuri/README.md
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/staticuri/README.md
@@ -1,4 +1,4 @@
-# Deep Link Basic Recipe
+# Deep Link Static URI Recipe
 
 This recipe demonstrates how deep link with a static Uri.
 

--- a/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/uriarguments/README.md
+++ b/app/src/main/java/com/example/nav3recipes/deeplink/handlerequests/uriarguments/README.md
@@ -1,4 +1,4 @@
-# Deep Link Basic Recipe
+# Deep Link URI Arguments Recipe
 
 This recipe demonstrates how to parse a deep link URL from an Android Intent into a Navigation key.
 


### PR DESCRIPTION
This PR updates the titles in the README files for the static URI and URI arguments deep link recipes to be more specific, resolving duplicate titles.